### PR TITLE
feat(plugin-integration): Add command 'integration:connections'

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,26 @@ USAGE
 ```
 # Commands
 <!-- commands -->
+* [`heroku integration:connections`](#heroku-integrationconnections)
 * [`heroku salesforce:connect ORG_NAME`](#heroku-salesforceconnect-org_name)
+
+## `heroku integration:connections`
+
+lists Heroku Integration connections
+
+```
+USAGE
+  $ heroku integration:connections [-a <value>] [-r <value>]
+
+FLAGS
+  -a, --app=<value>     app to run command against
+  -r, --remote=<value>  git remote of app to use
+
+DESCRIPTION
+  lists Heroku Integration connections
+```
+
+_See code: [dist/commands/integration/connections/index.ts](https://github.com/heroku/heroku-cli-plugin-integration/blob/v0.0.1/dist/commands/integration/connections/index.ts)_
 
 ## `heroku salesforce:connect ORG_NAME`
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "http-call": "^5",
     "mocha": "^10",
     "netrc-parser": "^3",
-    "nock": "^10",
+    "nock": "^13",
     "nyc": "^15",
     "oclif": "2.2.0",
     "sinon": "^14",

--- a/src/commands/integration/connections/index.ts
+++ b/src/commands/integration/connections/index.ts
@@ -1,0 +1,94 @@
+import {color} from '@heroku-cli/color'
+import Command from '../../../lib/base'
+import {flags} from '@heroku-cli/command'
+import * as Integration from '../../../lib/integration/types'
+import * as Heroku from '@heroku-cli/schema'
+import {ux} from '@oclif/core'
+import {arraySlice, humanize} from '../../../lib/helpers'
+
+type AppConnection = Pick<Heroku.AddOn, 'app'> & Integration.Connection
+type AppConnectionListUrl = Pick<Heroku.AddOn, 'app'> & {url: string}
+
+export default class Index extends Command {
+  static description = 'lists Heroku Integration connections'
+
+  static flags = {
+    app: flags.app(),
+    remote: flags.remote(),
+  }
+
+  public async run(): Promise<void> {
+    const {flags} = await this.parse(Index)
+    const {app} = flags
+    let appConnections: AppConnection[] = []
+
+    if (app) {
+      await this.configureIntegrationClient(app);
+      ({body: appConnections} = await this.integration.get<Integration.Connection[]>(`/addons/${this.addonId}/connections`))
+    } else {
+      const integrationAddons = await this.getIntegrationAddons()
+      appConnections = integrationAddons.length > 0 ? (await this.getAppConnections(integrationAddons)) : []
+    }
+
+    if (appConnections.length === 0) {
+      ux.log(`No Heroku Integration connections${app ? ` for app ${color.app(app)}` : ''}.`)
+    } else {
+      ux.styledHeader(`Heroku Integration connections${app ? ` for app ${color.app(app)}` : ''}`)
+
+      ux.table(appConnections, {
+        ...(app ? {} : {app: {get: row => row.app?.name}}),
+        type: {get: row => humanize(row.type)},
+        orgName: {header: 'Org Name', get: row => row.salesforce_org.org_name},
+        state: {get: row => humanize(row.state)},
+        runAsUser: {header: 'Run As User', get: row => row.salesforce_org.run_as_user || ''},
+      })
+    }
+  }
+
+  protected async getIntegrationAddons() {
+    const {body: addons} = await this.heroku.get<Required<Heroku.AddOn>[]>('/addons')
+    return addons.filter(addon => addon.addon_service?.name === this.addonServiceSlug)
+  }
+
+  protected async getAppConnections(integrationAddons: Required<Heroku.AddOn>[]): Promise<AppConnection[]> {
+    const appConnections: Array<AppConnection> = []
+
+    for (const addonsSlice of arraySlice(integrationAddons)) {
+      const appConnectionListUrls = await this.getAppConnectionListUrls(addonsSlice)
+      const connectionListPromises = appConnectionListUrls.map(appConnectionListUrl => {
+        return this.heroku.get<Integration.Connection[]>(
+          appConnectionListUrl.url,
+          {host: new URL(appConnectionListUrl.url).hostname}
+        )
+      })
+      const connectionListResponses = await Promise.all(connectionListPromises)
+      connectionListResponses.forEach((response, index) => {
+        const connections = response.body
+        connections.forEach(connection => {
+          appConnections.push({
+            app: addonsSlice[index].app,
+            ...connection,
+          })
+        })
+      })
+    }
+
+    return appConnections
+  }
+
+  protected async getAppConnectionListUrls(integrationAddons: Required<Heroku.AddOn>[]): Promise<AppConnectionListUrl[]> {
+    const configVarPromises = integrationAddons.map(addon => this.heroku.get<Heroku.ConfigVars>(`/apps/${addon.app.id}/config-vars`))
+    const configVarsResponses = await Promise.all(configVarPromises)
+    const appConnectionListUrls: Array<AppConnectionListUrl> = []
+
+    configVarsResponses.forEach((response, index) => {
+      const apiUrl = response.body[this.apiUrlConfigVarName]
+      if (apiUrl) appConnectionListUrls.push({
+        url: `${apiUrl}/connections`,
+        app: integrationAddons[index].app,
+      })
+    })
+
+    return appConnectionListUrls
+  }
+}

--- a/src/lib/base.ts
+++ b/src/lib/base.ts
@@ -12,6 +12,10 @@ export default abstract class extends Command {
     return process.env.HEROKU_INTEGRATION_ADDON || 'heroku-integration'
   }
 
+  get apiUrlConfigVarName(): string {
+    return `${this.addonServiceSlug.replace(/-/g, '_').toUpperCase()}_API_URL`
+  }
+
   get integration(): APIClient {
     if (this._integration)
       return this._integration
@@ -48,8 +52,7 @@ export default abstract class extends Command {
       )
     }
 
-    const apiUrlVarName = `${this.addonServiceSlug.replace(/-/g, '_').toUpperCase()}_API_URL`
-    const apiUrl = configVars[apiUrlVarName]
+    const apiUrl = configVars[this.apiUrlConfigVarName]
 
     if (!apiUrl) {
       ux.error(

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -5,12 +5,18 @@ const toTitleCase = (str: string) => {
   )
 }
 
-export function humanize(underscored: string): string {
-  return toTitleCase(underscored.replace('_', ' '))
+export function humanize(value?: string | null): string {
+  return toTitleCase((value || '').replace('_', ' ').replace(/([a-z])([A-Z])/g, '$1 $2'))
 }
 
 export function humanizeKeys(params: {[key: string]: string | null}): {[key: string]: string} {
   return Object.fromEntries(Object.entries(params).filter(([_, value]) => value).map(
     ([key, value]) => [humanize(key), value as string]
   ))
+}
+
+export function * arraySlice<T>(array: T[], size = 10): Generator<T[], void> {
+  for (let i = 0; i < array.length; i += size) {
+    yield array.slice(i, i + size)
+  }
 }

--- a/test/commands/integration/connections/index.test.ts
+++ b/test/commands/integration/connections/index.test.ts
@@ -1,0 +1,140 @@
+import {expect} from 'chai'
+import nock from 'nock'
+import {stderr, stdout} from 'stdout-stderr'
+import heredoc from 'tsheredoc'
+import {runCommand} from '../../../run-command'
+import Cmd from '../../../../src/commands/integration/connections/index'
+import stripAnsi from '../../../helpers/strip-ansi'
+import {addon, addon2, connection1, connection2_connected, connection3} from '../../../helpers/fixtures'
+
+describe('integration:connections', function () {
+  let api: nock.Scope
+  let integrationApi: nock.Scope
+  const {env} = process
+
+  beforeEach(function () {
+    process.env = {}
+    api = nock('https://api.heroku.com')
+    integrationApi = nock('https://integration-api.heroku.com')
+  })
+
+  afterEach(function () {
+    process.env = env
+    api.done()
+    integrationApi.done()
+    nock.cleanAll()
+  })
+
+  context('when the --app flag is specified', function () {
+    beforeEach(function () {
+      api.get('/apps/my-app/addons')
+        .reply(200, [addon])
+        .get('/apps/my-app/config-vars')
+        .reply(200, {
+          HEROKU_INTEGRATION_API_URL: 'https://integration-api.heroku.com/addons/01234567-89ab-cdef-0123-456789abcdef',
+        })
+    })
+
+    context('when there are no Heroku Integration connections created on the app', function () {
+      it('displays a notification', async function () {
+        integrationApi
+          .get('/addons/01234567-89ab-cdef-0123-456789abcdef/connections')
+          .reply(200, [])
+
+        await runCommand(Cmd, [
+          '--app=my-app',
+        ])
+
+        expect(stripAnsi(stdout.output)).to.equal('No Heroku Integration connections for app my-app.\n')
+        expect(stderr.output).to.equal('')
+      })
+    })
+
+    context('when there are Heroku Integration connections returned', function () {
+      it('shows the connections', async function () {
+        integrationApi
+          .get('/addons/01234567-89ab-cdef-0123-456789abcdef/connections')
+          .reply(200, [connection1, connection2_connected])
+
+        await runCommand(Cmd, [
+          '--app',
+          'my-app',
+        ])
+
+        expect(stripAnsi(stdout.output)).to.equal(heredoc`
+          === Heroku Integration connections for app my-app
+  
+           Type           Org Name State     Run As User      
+           ────────────── ──────── ───────── ──────────────── 
+           Salesforce Org my-org-1 Connected user@example.com 
+           Salesforce Org my-org-2 Connected user@example.com 
+        `)
+        expect(stderr.output).to.equal('')
+      })
+    })
+  })
+
+  context('when the --app flag isn’t specified', function () {
+    context('when there are no Heroku Integration addons', function () {
+      beforeEach(function () {
+        api.get('/addons').reply(200, [])
+      })
+
+      it('displays a notification', async function () {
+        await runCommand(Cmd)
+
+        expect(stripAnsi(stdout.output)).to.equal('No Heroku Integration connections.\n')
+        expect(stderr.output).to.equal('')
+      })
+    })
+
+    context('when there are Heroku Integration addons', function () {
+      beforeEach(function () {
+        api.get('/addons')
+          .reply(200, [addon, addon2])
+          .get('/apps/89abcdef-0123-4567-89ab-cdef01234567/config-vars')
+          .reply(200, {
+            HEROKU_INTEGRATION_API_URL: 'https://integration-api.heroku.com/addons/01234567-89ab-cdef-0123-456789abcdef',
+          })
+          .get('/apps/abcdef01-2345-6789-abcd-ef0123456789/config-vars')
+          .reply(200, {
+            HEROKU_INTEGRATION_API_URL: 'https://integration-api.heroku.com/addons/6789abcd-ef01-2345-6789-abcdef012345',
+          })
+      })
+
+      it('displays a notification when there are no Heroku Integration connections on any app', async function () {
+        integrationApi
+          .get('/addons/01234567-89ab-cdef-0123-456789abcdef/connections')
+          .reply(200, [])
+          .get('/addons/6789abcd-ef01-2345-6789-abcdef012345/connections')
+          .reply(200, [])
+
+        await runCommand(Cmd)
+
+        expect(stripAnsi(stdout.output)).to.equal('No Heroku Integration connections.\n')
+        expect(stderr.output).to.equal('')
+      })
+
+      it('shows the connections when there are Heroku Integration connections returned', async function () {
+        integrationApi
+          .get('/addons/01234567-89ab-cdef-0123-456789abcdef/connections')
+          .reply(200, [connection1, connection2_connected])
+          .get('/addons/6789abcd-ef01-2345-6789-abcdef012345/connections')
+          .reply(200, [connection3])
+
+        await runCommand(Cmd)
+
+        expect(stripAnsi(stdout.output)).to.equal(heredoc`
+          === Heroku Integration connections
+
+           App          Type           Org Name State      Run As User       
+           ──────────── ────────────── ──────── ────────── ───────────────── 
+           my-app       Salesforce Org my-org-1 Connected  user@example.com  
+           my-app       Salesforce Org my-org-2 Connected  user@example.com  
+           my-other-app Datacloud Org  my-org-1 Connecting user2@example.com 
+        `)
+        expect(stderr.output).to.equal('')
+      })
+    })
+  })
+})

--- a/test/helpers/fixtures.ts
+++ b/test/helpers/fixtures.ts
@@ -2,11 +2,29 @@ import * as Heroku from '@heroku-cli/schema'
 import * as Integration from '../../src/lib/integration/types'
 
 export const addon: Heroku.AddOn = {
-  name: 'heroku-integration-vertical-01234',
   addon_service: {
-    id: '01234567-89ab-cdef-0123-456789abcdef',
+    id: '23456789-abcd-ef01-2345-6789abcdef01',
     name: 'heroku-integration',
   },
+  app: {
+    id: '89abcdef-0123-4567-89ab-cdef01234567',
+    name: 'my-app',
+  },
+  id: '01234567-89ab-cdef-0123-456789abcdef',
+  name: 'heroku-integration-vertical-01234',
+}
+
+export const addon2: Heroku.AddOn = {
+  addon_service: {
+    id: '456789ab-cdef-0123-4567-89abcdef0123',
+    name: 'heroku-integration',
+  },
+  app: {
+    id: 'abcdef01-2345-6789-abcd-ef0123456789',
+    name: 'my-other-app',
+  },
+  id: '6789abcd-ef01-2345-6789-abcdef012345',
+  name: 'heroku-integration-horizontal-01234',
 }
 
 export const connection1: Integration.Connection = {
@@ -52,4 +70,15 @@ export const connection2_failed: Integration.Connection = {
   },
   state: 'connection_failed',
   type: 'SalesforceOrg',
+}
+
+export const connection3: Integration.Connection = {
+  salesforce_org: {
+    id: '00DSG000007a3FdB96',
+    instance_url: 'https://dsg000007a3fdb96.test1.my.pc-rnd.salesforce.com',
+    org_name: 'my-org-1',
+    run_as_user: 'user2@example.com',
+  },
+  state: 'connecting',
+  type: 'DatacloudOrg',
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1275,19 +1275,6 @@ chai@^4:
     pathval "^1.1.1"
     type-detect "^4.0.8"
 
-chai@^4.1.2:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/chai/-/chai-4.5.0.tgz#707e49923afdd9b13a8b0b47d33d732d13812fd8"
-  integrity sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==
-  dependencies:
-    assertion-error "^1.1.0"
-    check-error "^1.0.3"
-    deep-eql "^4.1.3"
-    get-func-name "^2.0.2"
-    loupe "^2.3.6"
-    pathval "^1.1.1"
-    type-detect "^4.1.0"
-
 chalk@^1.0.0:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
@@ -1787,18 +1774,6 @@ deep-eql@^4.1.3:
   integrity sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==
   dependencies:
     type-detect "^4.0.0"
-
-deep-equal@^1.0.0:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.1.2.tgz#78a561b7830eef3134c7f6f3a3d6af272a678761"
-  integrity sha512-5tdhKF6DbU7iIzrIOa1AOUt39ZRm13cmL1cGEh//aqR8x9+tNfbywRf0n5FD/18OKMdo7DNEtrX2t22ZAkI+eg==
-  dependencies:
-    is-arguments "^1.1.1"
-    is-date-object "^1.0.5"
-    is-regex "^1.1.4"
-    object-is "^1.1.5"
-    object-keys "^1.1.1"
-    regexp.prototype.flags "^1.5.1"
 
 deep-extend@^0.6.0:
   version "0.6.0"
@@ -3377,14 +3352,6 @@ is-accessor-descriptor@^1.0.1:
   dependencies:
     hasown "^2.0.0"
 
-is-arguments@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/is-arguments/-/is-arguments-1.1.1.tgz#15b3f88fda01f2a97fec84ca761a560f123efa9b"
-  integrity sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==
-  dependencies:
-    call-bind "^1.0.2"
-    has-tostringtag "^1.0.0"
-
 is-array-buffer@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/is-array-buffer/-/is-array-buffer-3.0.4.tgz#7a1f92b3d61edd2bc65d24f130530ea93d7fae98"
@@ -3458,7 +3425,7 @@ is-data-view@^1.0.1:
   dependencies:
     is-typed-array "^1.1.13"
 
-is-date-object@^1.0.1, is-date-object@^1.0.5:
+is-date-object@^1.0.1:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.5.tgz#0841d5536e724c25597bf6ea62e1bd38298df31f"
   integrity sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==
@@ -4045,7 +4012,7 @@ lodash.truncate@^4.4.2:
   resolved "https://registry.yarnpkg.com/lodash.truncate/-/lodash.truncate-4.4.2.tgz#5a350da0b1113b837ecfffd5812cbe58d6eae193"
   integrity sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==
 
-lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.21, lodash@^4.17.5, lodash@^4.5.1:
+lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.21, lodash@^4.5.1:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -4469,20 +4436,14 @@ nise@^5.1.2:
     just-extend "^6.2.0"
     path-to-regexp "^6.2.1"
 
-nock@^10:
-  version "10.0.6"
-  resolved "https://registry.yarnpkg.com/nock/-/nock-10.0.6.tgz#e6d90ee7a68b8cfc2ab7f6127e7d99aa7d13d111"
-  integrity sha512-b47OWj1qf/LqSQYnmokNWM8D88KvUl2y7jT0567NB3ZBAZFz2bWp2PC81Xn7u8F2/vJxzkzNZybnemeFa7AZ2w==
+nock@^13:
+  version "13.5.5"
+  resolved "https://registry.yarnpkg.com/nock/-/nock-13.5.5.tgz#cd1caaca281d42be17d51946367a3d53a6af3e78"
+  integrity sha512-XKYnqUrCwXC8DGG1xX4YH5yNIrlh9c065uaMZZHUoeUUINTOyt+x/G+ezYk0Ft6ExSREVIs+qBJDK503viTfFA==
   dependencies:
-    chai "^4.1.2"
     debug "^4.1.0"
-    deep-equal "^1.0.0"
     json-stringify-safe "^5.0.1"
-    lodash "^4.17.5"
-    mkdirp "^0.5.0"
-    propagate "^1.0.0"
-    qs "^6.5.1"
-    semver "^5.5.0"
+    propagate "^2.0.0"
 
 nock@^13.3.3:
   version "13.5.4"
@@ -4635,14 +4596,6 @@ object-inspect@^1.13.1:
   version "1.13.2"
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.13.2.tgz#dea0088467fb991e67af4058147a24824a3043ff"
   integrity sha512-IRZSRuzJiynemAXPYtPe5BoI/RESNYR7TYm50MC5Mqbd3Jmw5y790sErYw3V6SryFJD64b74qQQs9wn5Bg/k3g==
-
-object-is@^1.1.5:
-  version "1.1.6"
-  resolved "https://registry.yarnpkg.com/object-is/-/object-is-1.1.6.tgz#1a6a53aed2dd8f7e6775ff870bea58545956ab07"
-  integrity sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==
-  dependencies:
-    call-bind "^1.0.7"
-    define-properties "^1.2.1"
 
 object-keys@^1.1.1:
   version "1.1.1"
@@ -5090,11 +5043,6 @@ progress@^2.0.0:
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
   integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
 
-propagate@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/propagate/-/propagate-1.0.0.tgz#00c2daeedda20e87e3782b344adba1cddd6ad709"
-  integrity sha512-T/rqCJJaIPYObiLSmaDsIf4PGA7y+pkgYFHmwoXQyOHiDDSO1YCxcztNiRBmV4EZha4QIbID3vQIHkqKu5k0Xg==
-
 propagate@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/propagate/-/propagate-2.0.1.tgz#40cdedab18085c792334e64f0ac17256d38f9a45"
@@ -5136,13 +5084,6 @@ qqjs@^0.3.10:
     tar-fs "^2.0.0"
     tmp "^0.1.0"
     write-json-file "^4.1.1"
-
-qs@^6.5.1:
-  version "6.12.3"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.12.3.tgz#e43ce03c8521b9c7fd7f1f13e514e5ca37727754"
-  integrity sha512-AWJm14H1vVaO/iNZ4/hO+HyaTehuy9nRqVdkTqlJt0HWvBiBIEXFmb4C0DGeYo3Xes9rrEW+TxHsaigCbN5ICQ==
-  dependencies:
-    side-channel "^1.0.6"
 
 queue-microtask@^1.2.2:
   version "1.2.3"
@@ -5299,7 +5240,7 @@ regexp-tree@^0.1.23, regexp-tree@~0.1.1:
   resolved "https://registry.yarnpkg.com/regexp-tree/-/regexp-tree-0.1.27.tgz#2198f0ef54518ffa743fe74d983b56ffd631b6cd"
   integrity sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA==
 
-regexp.prototype.flags@^1.5.1, regexp.prototype.flags@^1.5.2:
+regexp.prototype.flags@^1.5.2:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/regexp.prototype.flags/-/regexp.prototype.flags-1.5.2.tgz#138f644a3350f981a858c44f6bb1a61ff59be334"
   integrity sha512-NcDiDkTLuPR+++OCKB0nWafEmhg/Da8aUPLPMQbK+bxKKCm1/S5he+AqYa4PlMCVBalb4/yxIRub6qkEx5yJbw==
@@ -5607,7 +5548,7 @@ shelljs@^0.8.0, shelljs@^0.8.4:
     interpret "^1.0.0"
     rechoir "^0.6.2"
 
-side-channel@^1.0.4, side-channel@^1.0.6:
+side-channel@^1.0.4:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/side-channel/-/side-channel-1.0.6.tgz#abd25fb7cd24baf45466406b1096b7831c9215f2"
   integrity sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==
@@ -6223,11 +6164,6 @@ type-detect@4.0.8, type-detect@^4.0.0, type-detect@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
   integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
-
-type-detect@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.1.0.tgz#deb2453e8f08dcae7ae98c626b13dddb0155906c"
-  integrity sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==
 
 type-fest@^0.20.2:
   version "0.20.2"


### PR DESCRIPTION
## Description

Here we're adding the implementation and unit tests for command `integration:connections`, according to the design outlined in the [UX design doc](https://salesforce.quip.com/8ZpbAsmjR42g#temp:C:cUG14c5683042134c56944b29b8d).

## How to test

### Prepare your environment for testing
- Fetch this branch.
- Run ```yarn && yarn build```.
- Export the env var ```HEROKU_INTEGRATION_ADDON="heroku-integration-staging"``` so you don't have to provide the setting on each command execution.

### Actual testing

- Verify that help looks ok: ```./bin/run integration:connections --help```
- Run ```./bin/run integration:connections``` and verify that the command succeeds without specifying an app and it shows the message `No Heroku Integration connections` when you don't have any Heroku Integration add-ons accessible.
- Install the add-on on a test app: ```heroku addons:create heroku-integration-staging -a <test-app>```
- Run: ```./bin/run integration:connections``` again and verify that you get the same notification.
- Run: ```./bin/run salesforce:connect test-connection -a <test-app>```. It isn't necessary for you to complete the OAuth flow, but if you want to do that, login with the following credentials: `epic.3aafa7566132@salesforce.com`, password: `orgfarm1234`.
- Run: ```./bin/run integration:connections``` again and verify that you get the info for the created connection in the table.
- Repeat the steps on a second test app, installing the add-on again and creating a connection with a different name.
- Run: ```./bin/run integration:connections``` again and verify that you get the info for both connections in the table, each one assigned to the correct app.
- Run: ```./bin/run integration:connections -a <test-app>```, you should see only the connections for the targeted app.

## SOC2 Compliance

[GUS Work Item](https://gus.lightning.force.com/a07EE00001zViUcYAK)