### PR TITLE
feat(plugin-integration): Add command 'integration:connections:info'

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ USAGE
 # Commands
 <!-- commands -->
 * [`heroku integration:connections`](#heroku-integrationconnections)
+* [`heroku integration:connections:info ORG_NAME`](#heroku-integrationconnectionsinfo-org_name)
 * [`heroku salesforce:connect ORG_NAME`](#heroku-salesforceconnect-org_name)
 
 ## `heroku integration:connections`
@@ -45,6 +46,27 @@ DESCRIPTION
 ```
 
 _See code: [dist/commands/integration/connections/index.ts](https://github.com/heroku/heroku-cli-plugin-integration/blob/v0.0.1/dist/commands/integration/connections/index.ts)_
+
+## `heroku integration:connections:info ORG_NAME`
+
+shows info for a Heroku Integration connection
+
+```
+USAGE
+  $ heroku integration:connections:info [ORG_NAME] -a <value> [-r <value>]
+
+ARGUMENTS
+  ORG_NAME  connected org name
+
+FLAGS
+  -a, --app=<value>     (required) app to run command against
+  -r, --remote=<value>  git remote of app to use
+
+DESCRIPTION
+  shows info for a Heroku Integration connection
+```
+
+_See code: [dist/commands/integration/connections/info.ts](https://github.com/heroku/heroku-cli-plugin-integration/blob/v0.0.1/dist/commands/integration/connections/info.ts)_
 
 ## `heroku salesforce:connect ORG_NAME`
 

--- a/src/commands/integration/connections/info.ts
+++ b/src/commands/integration/connections/info.ts
@@ -1,0 +1,39 @@
+import Command from '../../../lib/base'
+import {flags} from '@heroku-cli/command'
+import * as Integration from '../../../lib/integration/types'
+import {Args, ux} from '@oclif/core'
+import {humanize} from '../../../lib/helpers'
+
+export default class Info extends Command {
+  static description = 'shows info for a Heroku Integration connection'
+
+  static flags = {
+    app: flags.app({required: true}),
+    remote: flags.remote(),
+  }
+
+  static args = {
+    org_name: Args.string({description: 'connected org name', required: true}),
+  }
+
+  public async run(): Promise<void> {
+    const {flags, args} = await this.parse(Info)
+    const {app} = flags
+    const {org_name: orgName} = args
+
+    await this.configureIntegrationClient(app)
+    const {body: connection} = await this.integration.get<Integration.Connection>(
+      `/addons/${this.addonId}/connections/${orgName}`
+    )
+
+    ux.styledObject({
+      Id: connection.id,
+      'Instance URL': connection.salesforce_org.instance_url,
+      'Org ID': connection.salesforce_org.id,
+      'Org Name': connection.salesforce_org.org_name,
+      'Run As User': connection.salesforce_org.run_as_user,
+      State: humanize(connection.state),
+      Type: humanize(connection.type),
+    })
+  }
+}


### PR DESCRIPTION
## Description

Here we're adding the implementation and unit tests for command `integration:connections:info`, according to the design outlined in the [UX design doc](https://salesforce.quip.com/8ZpbAsmjR42g#temp:C:cUG6d4d2a60a41e429f821f32cd7).

There are changes re-introduced here from my previous PR for `integration:connections`, but required to avoid failures on test or duplicating fixtures that can be reused.

## How to test

### Prepare your environment for testing
- Fetch this branch.
- Run ```yarn && yarn build```.
- Install the add-on on a test app: ```heroku addons:create heroku-integration-staging -a <test-app>```
- Export the env var ```HEROKU_INTEGRATION_ADDON="heroku-integration-staging"``` so you don't have to provide the setting on each command execution.

### Actual testing

(These instructions assume that `integration:connections` has already been merged).

- Verify that help looks ok: ```./bin/run integration:connections:info --help```
- Run ```./bin/run integration:connections``` and grab any existing connection's Org Name or create a connection with ```./bin/run salesforce:connect test-connection -a <test-app>```. It isn't necessary for you to complete the OAuth flow, but if you want to do that, login with the following credentials: `epic.3aafa7566132@salesforce.com`, password: `orgfarm1234`.
- Run: ```./bin/run integration:connections:info <org_name>``` and verify the command shows the connection info without errors.

## SOC2 Compliance

[GUS Work Item](https://gus.lightning.force.com/a07EE00001zVf0RYAS)