### PR TITLE
Fixing generator namespace

### DIFF
--- a/src/commands/integration/project.ts
+++ b/src/commands/integration/project.ts
@@ -39,9 +39,9 @@ export default class Project extends Command {
     const {project_name: projectName} = args
     const yeomanEnv = Project.yeomanEnvCreator()
 
-    yeomanEnv.lookup()
+    yeomanEnv.lookup({localOnly: true, packagePatterns: ['@heroku/generator-*']})
     await yeomanEnv.run(
-      `heroku-integration:${projectType}-${language}`, {
+      `@heroku/heroku-integration:${projectType}-${language}`, {
         projectName,
         outputDirectory: outputDirectory || `./${projectName}`,
       }

--- a/test/commands/integration/project.test.ts
+++ b/test/commands/integration/project.test.ts
@@ -31,7 +31,7 @@ describe('integration:project', function () {
       ])
 
       expect(yeomanEnvRunSpy.calledWith(
-        'heroku-integration:salesforce-javascript',
+        '@heroku/heroku-integration:salesforce-javascript',
         {
           projectName,
           outputDirectory: `./${projectName}`,
@@ -50,7 +50,7 @@ describe('integration:project', function () {
       ])
 
       expect(yeomanEnvRunSpy.calledWith(
-        'heroku-integration:salesforce-javascript',
+        '@heroku/heroku-integration:salesforce-javascript',
         {
           projectName,
           outputDirectory: customOutputDirectory,


### PR DESCRIPTION
## Description

When the plugin is installed from NPM, the `integration:project` command fails to lookup the required Yeoman generator because, by default, it looks for package names following the pattern `generator-*` and we finally published to NPM under our `@heroku` org, making impossible for the lookup method to find the installed dependency.

Here we change the lookup options to only search on local dependency folders for generator package names following a `@heroku/generator-*` pattern, fixing the issue.

## How to test

### Prepare your environment for testing
- Fetch this branch.
- Run ```yarn && yarn build```.

### Actual testing

- Verify that help looks ok: ```./bin/run integration:project --help``` (reminder that the `--project-type` and `--language` option flags are hidden for now, until we have more project types and languages. Default values are `salesforce` and `javascript` respectively, being the only accepted values for those flags.
- Run: ```./bin/run integration:project test-integration-project``` and verify it creates a scaffold for the project under the default output directory `./test-integration-project`. You can remove the directory afterwards.
- Run: ```./bin/run integration:project test-integration-project -o ./my-custom-dir``` and verify it creates a scaffold for the project under the output directory `./my-custom-dir`. You can remove the directory afterwards.

## SOC2 Compliance

[GUS Work Item](https://gus.lightning.force.com/a07EE00001zVtHcYAK)