### PR TITLE
fix(plugin-integration): Fix search path for Yeoman lookups

### DIFF
--- a/src/commands/integration/project.ts
+++ b/src/commands/integration/project.ts
@@ -2,6 +2,7 @@ import {flags} from '@heroku-cli/command'
 import {Args} from '@oclif/core'
 import {createEnv} from 'yeoman-environment'
 import Command from '../../lib/base'
+import * as path from 'node:path'
 
 export default class Project extends Command {
   static description = 'generates a Heroku Integration project template'
@@ -39,7 +40,11 @@ export default class Project extends Command {
     const {project_name: projectName} = args
     const yeomanEnv = Project.yeomanEnvCreator()
 
-    yeomanEnv.lookup({localOnly: true, packagePatterns: ['@heroku/generator-*']})
+    yeomanEnv.lookup({
+      packagePatterns: ['@heroku/generator-*'],
+      npmPaths: [path.join(path.dirname(require.resolve('@heroku/generator-heroku-integration')), '../../../..')],
+    })
+
     await yeomanEnv.run(
       `@heroku/heroku-integration:${projectType}-${language}`, {
         projectName,


### PR DESCRIPTION
## Description

In our last PR we fixed an issue with the `integration:project` command where it failed to lookup the required Yeoman generator because it was looking with a wrong pattern `generator-*`. The issues finding the generator continued because when developing locally, Yeoman's lookup method adds any `node_modules` under the current directory and it hadn't issues finding the generator. Once installed on a user device, where the command is run under any other directory that doesn't contain the `node_modules` where the generator is located, it fails.

Here we change the lookup options to search starting on the `node_modules` directory where the generator has been installed on the user's device, fixing the issue.

## How to test

### Prepare your environment for testing
- Fetch this branch.
- Run ```yarn && yarn build```.

### Actual testing

- Change to any directory that doesn't have the `node_modules` as a child from your current directory.
- Run: ```DEBUG=yeoman:* <path-to-the-plugin-repo>/bin/run integration:project test-integration-project``` and verify that the debug output includes the correct `npmPaths` value (array containing the absolute path to your repo's `node_modules` directory) and that it creates a scaffold for the project under the default output directory `./test-integration-project`. You can remove the directory afterwards.

## SOC2 Compliance

[GUS Work Item](https://gus.lightning.force.com/a07EE00001zVtHcYAK)