### PR TITLE
chore: bump @heroku/generator-heroku-integration to v0.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@heroku-cli/color": "^2",
     "@heroku-cli/command": "^11",
     "@heroku-cli/schema": "^1.0.25",
-    "@heroku/generator-heroku-integration": "^0.0.3",
+    "@heroku/generator-heroku-integration": "^0.0.4",
     "@oclif/core": "^2.16.0",
     "@oclif/plugin-help": "^5",
     "open": "^8.4.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -286,10 +286,10 @@
   resolved "https://registry.yarnpkg.com/@heroku-cli/schema/-/schema-1.0.25.tgz#175d489d82c2ff0be700fe9fab8590b64c7e4f39"
   integrity sha512-7V6/WdTHrsvpqeqttm4zhzVJyt/Us/Cz9oS4yure4JdLtwlr2eF6PvlDLA5ZIvBybMtSDyxhHid0PeshKLtwxw==
 
-"@heroku/generator-heroku-integration@^0.0.3":
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/@heroku/generator-heroku-integration/-/generator-heroku-integration-0.0.3.tgz#ad9d729b7e1e35f13334f9ee9ddbcb5061d9da35"
-  integrity sha512-Zsga9M8rr+heYR3dv080E95bGWZCbjfB1eMTZk6ddBQE7ouxUVqrA7B9MGB3mihYK4AocMmfFRYrJAMjXPHJfg==
+"@heroku/generator-heroku-integration@^0.0.4":
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/@heroku/generator-heroku-integration/-/generator-heroku-integration-0.0.4.tgz#e605b6e99d065fb274733f3534cb5d19fd97668c"
+  integrity sha512-NQIpcHWOfx64NL/PE2PfRVtFJjetvMpLipHcmJ/k3sBZhiRIsaOCZtshdPTVpLBJXDf4r1drWMGNENGjE2vLMA==
   dependencies:
     chalk "^2.1.0"
     yeoman-generator "^4.8.2"
@@ -6528,10 +6528,10 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@5.3.3:
-  version "5.3.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.3.3.tgz#b3ce6ba258e72e6305ba66f5c9b452aaee3ffe37"
-  integrity sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==
+typescript@^5.3.3:
+  version "5.6.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.6.2.tgz#d1de67b6bef77c41823f822df8f0b3bcff60a5a0"
+  integrity sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==
 
 unbox-primitive@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
Bumping the version of @heroku/generator-heroku-integration to v0.0.4 to capture latest changes.