### PR TITLE
Bumping the generator dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@heroku-cli/color": "^2",
     "@heroku-cli/command": "^11",
     "@heroku-cli/schema": "^1.0.25",
-    "@heroku/generator-heroku-integration": "^0.0.6",
+    "@heroku/generator-heroku-integration": "^0.0.7",
     "@oclif/core": "^2.16.0",
     "@oclif/plugin-help": "^5",
     "open": "^8.4.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -286,10 +286,10 @@
   resolved "https://registry.yarnpkg.com/@heroku-cli/schema/-/schema-1.0.25.tgz#175d489d82c2ff0be700fe9fab8590b64c7e4f39"
   integrity sha512-7V6/WdTHrsvpqeqttm4zhzVJyt/Us/Cz9oS4yure4JdLtwlr2eF6PvlDLA5ZIvBybMtSDyxhHid0PeshKLtwxw==
 
-"@heroku/generator-heroku-integration@^0.0.6":
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/@heroku/generator-heroku-integration/-/generator-heroku-integration-0.0.6.tgz#6ccd58c653e912055c61dc718f181b666f2ac9b4"
-  integrity sha512-bYF/Z4b8QWedPLdyikZH9kYOhOyqhoOuPZsz5HT2YjGoIlpiBIdQcojISbvP8/Y2hrjMq++wcRe/cS/tQ3Q62Q==
+"@heroku/generator-heroku-integration@^0.0.7":
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/@heroku/generator-heroku-integration/-/generator-heroku-integration-0.0.7.tgz#e46ae1eb91bcd18655f4a0119281ca915694e8d0"
+  integrity sha512-AgEFx5wW7ZfDHdkMBsoteE5KpMjc3N2hboMsNmbJs/6efhrdd62LauhG5KKWipdaQeg8pT/d1V3V/MXfVFvX+w==
   dependencies:
     chalk "^2.1.0"
     yeoman-generator "^4.8.2"


### PR DESCRIPTION
## Description

Here we just bump the `@heroku/generator-heroku-integration` dependency to the last version to overcome a failure on the previous version released.

## SOC2
[Slack thread](https://salesforce-internal.slack.com/archives/C1RU5S0G2/p1729871405857119?thread_ts=1729780649.556679&cid=C1RU5S0G2) (Heroku internal)