### PR TITLE
Use v0.0.10 of generator-heroku-plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@heroku-cli/color": "^2",
     "@heroku-cli/command": "^11",
     "@heroku-cli/schema": "^1.0.25",
-    "@heroku/generator-heroku-integration": "^0.0.9",
+    "@heroku/generator-heroku-integration": "^0.0.10",
     "@oclif/core": "^2.16.0",
     "@oclif/plugin-help": "^5",
     "open": "^8.4.2",


### PR DESCRIPTION
Bump to latest version of generator-heroku-integration

[Slack](https://salesforce-internal.slack.com/archives/C06EA6CPVST/p1740499352998369) context

Fixes in v0.0.10 of generator-heroku-integration:
[@W-17597105](https://gus.lightning.force.com/a07EE000027zLR3YAM)