### PR TITLE
refactor: change state to status in output for integration:connections

### DIFF
--- a/src/commands/integration/connections/index.ts
+++ b/src/commands/integration/connections/index.ts
@@ -42,7 +42,7 @@ export default class Index extends Command {
           header: 'Org Name',
           get: row => Integration.isSalesforceConnection(row) ? row.salesforce_org.org_name : row.datacloud_org.org_name,
         },
-        state: {get: row => humanize(row.state)},
+        status: {get: row => humanize(row.state)},
         runAsUser: {
           header: 'Run As User',
           get: row => Integration.isSalesforceConnection(row) ? row.salesforce_org.run_as_user : row.datacloud_org.run_as_user,

--- a/src/commands/integration/connections/info.ts
+++ b/src/commands/integration/connections/info.ts
@@ -45,7 +45,7 @@ export default class Info extends Command {
       'Org ID': orgInfo.id,
       'Org Name': orgInfo.org_name,
       'Run As User': orgInfo.run_as_user,
-      State: humanize(connection.state),
+      Status: humanize(connection.state),
       Type: humanize(Integration.adjustConnectionType(connection.type)),
     })
   }

--- a/test/commands/integration/connections/index.test.ts
+++ b/test/commands/integration/connections/index.test.ts
@@ -63,7 +63,7 @@ describe('integration:connections', function () {
         expect(stripAnsi(stdout.output)).to.equal(heredoc`
           === Heroku Integration connections for app my-app
   
-           Type           Org Name State     Run As User      
+           Type           Org Name Status    Run As User      
            ────────────── ──────── ───────── ──────────────── 
            Salesforce Org my-org-1 Connected user@example.com 
            Salesforce Org my-org-2 Connected user@example.com 
@@ -126,7 +126,7 @@ describe('integration:connections', function () {
         expect(stripAnsi(stdout.output)).to.equal(heredoc`
           === Heroku Integration connections
 
-           App          Type           Org Name State      Run As User       
+           App          Type           Org Name Status     Run As User       
            ──────────── ────────────── ──────── ────────── ───────────────── 
            my-app       Salesforce Org my-org-1 Connected  user@example.com  
            my-app       Salesforce Org my-org-2 Connected  user@example.com  

--- a/test/commands/integration/connections/info.test.ts
+++ b/test/commands/integration/connections/info.test.ts
@@ -52,7 +52,7 @@ describe('integration:connections:info', function () {
       Org ID:       00DSG000007a3BcA84
       Org Name:     my-org-2
       Run As User:  user@example.com
-      State:        Connected
+      Status:       Connected
       Type:         Salesforce Org
     `)
     expect(stderr.output).to.equal('')


### PR DESCRIPTION
[Work Item](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE0000288uFbYAI/view)

Changes `State` to `Status` in the output tables for `integration:connections` and `integration:connections:info`.

## Testing
### Setup
- Checkout this branch
- Run `yarn && yarn build`
- Install the add-on on a test app: `heroku addons:create heroku-integration-staging -a <test-app>`
    - If you get an error, you may need to install the prod add-on: `heroku addons:create heroku-integration -a <test-app>`. If you aren't already added to the pilot program, you will need to request access.
- Run: `./bin/run salesforce:connect test-connection -a <test-app>`. It isn't necessary for you to complete the OAuth flow.

### Test
- Run `./bin/run integration:connections`. You should see a table that lists your test app and your new connection. The table should have a "Status" column.
- Run `./bin/run integration:connections:info test-connection -a <test-app>`. You should see information about the connection with a "Status" item.