### PR TITLE
refactor: set authorization header as part of applink api call

### DIFF
--- a/src/commands/applink/authorizations/index.ts
+++ b/src/commands/applink/authorizations/index.ts
@@ -19,7 +19,9 @@ export default class Index extends Command {
     const {addon, app} = flags
 
     await this.configureAppLinkClient(app, addon)
-    const {body: appAuthorizations} = await this.applinkClient.get<AppLink.Authorization[]>(`/addons/${this.addonId}/authorizations`)
+    const {body: appAuthorizations} = await this.applinkClient.get<AppLink.Authorization[]>(`/addons/${this.addonId}/authorizations`, {
+      headers: {authorization: `Bearer ${this._applinkToken}`},
+    })
 
     if (appAuthorizations.length === 0) {
       ux.log(`There are no Heroku AppLink authorizations for add-on ${this._addonName} on app ${color.app(app)}.`)

--- a/src/commands/applink/authorizations/info.ts
+++ b/src/commands/applink/authorizations/info.ts
@@ -27,7 +27,9 @@ export default class Info extends Command {
     let authorization: AppLink.Authorization
     try {
       ({body: authorization} = await this.applinkClient.get<AppLink.Authorization>(
-        `/addons/${this.addonId}/authorizations/${developerName}`
+        `/addons/${this.addonId}/authorizations/${developerName}`, {
+          headers: {authorization: `Bearer ${this._applinkToken}`},
+        }
       ))
     } catch (error) {
       const connErr = error as AppLink.ConnectionError

--- a/src/commands/applink/connections/index.ts
+++ b/src/commands/applink/connections/index.ts
@@ -23,7 +23,9 @@ export default class Index extends Command {
     let appConnections: AppConnection[] = []
 
     await this.configureAppLinkClient(app, addon);
-    ({body: appConnections} = await this.applinkClient.get<AppLink.Connection[]>(`/addons/${this.addonId}/connections`))
+    ({body: appConnections} = await this.applinkClient.get<AppLink.Connection[]>(`/addons/${this.addonId}/connections`, {
+      headers: {authorization: `Bearer ${this._applinkToken}`},
+    }))
 
     if (appConnections.length === 0) {
       ux.log(`No Heroku AppLink connections${app ? ` for app ${color.app(app)}` : ''}.`)

--- a/src/commands/applink/connections/info.ts
+++ b/src/commands/applink/connections/info.ts
@@ -27,7 +27,9 @@ export default class Info extends Command {
     let connection: AppLink.Connection
     try {
       ({body: connection} = await this.applinkClient.get<AppLink.Connection>(
-        `/addons/${this.addonId}/connections/${orgName}`
+        `/addons/${this.addonId}/connections/${orgName}`, {
+          headers: {authorization: `Bearer ${this._applinkToken}`},
+        }
       ))
     } catch (error) {
       const connErr = error as AppLink.ConnectionError

--- a/src/commands/datacloud/connect.ts
+++ b/src/commands/datacloud/connect.ts
@@ -35,6 +35,7 @@ export default class Connect extends Command {
     ({body: connection} = await this.applinkClient.post<AppLink.DataCloudConnection>(
       `/addons/${this.addonId}/connections/datacloud`,
       {
+        headers: {authorization: `Bearer ${this._applinkToken}`},
         body: {
           login_url: loginUrl,
           org_name: orgName,

--- a/src/commands/datacloud/data-action-target/create.ts
+++ b/src/commands/datacloud/data-action-target/create.ts
@@ -49,6 +49,7 @@ export default class Create extends Command {
     const {body: createResp} = await this.applinkClient.post<AppLink.DataActionTargetCreate>(
       `/addons/${this.addonId}/connections/datacloud/${orgName}/data_action_targets`,
       {
+        headers: {authorization: `Bearer ${this._applinkToken}`},
         body: {
           api_name: apiName,
           label,

--- a/src/commands/datacloud/disconnect.ts
+++ b/src/commands/datacloud/disconnect.ts
@@ -39,7 +39,9 @@ export default class Disconnect extends Command {
 
     try {
       ({body: connection} = await this.applinkClient.delete<AppLink.DataCloudConnection>(
-        `/addons/${this.addonId}/connections/${orgName}`
+        `/addons/${this.addonId}/connections/${orgName}`, {
+          headers: {authorization: `Bearer ${this._applinkToken}`},
+        }
       ))
     } catch (error) {
       const connErr = error as ConnectionError

--- a/src/commands/salesforce/authorize.ts
+++ b/src/commands/salesforce/authorize.ts
@@ -35,6 +35,7 @@ export default class Authorize extends Command {
     ({body: authorization} = await this.applinkClient.post<AppLink.Authorization>(
       `/addons/${this.addonId}/authorizations`,
       {
+        headers: {authorization: `Bearer ${this._applinkToken}`},
         body: {
           login_url: loginUrl,
           developer_name: developerName,

--- a/src/commands/salesforce/connect.ts
+++ b/src/commands/salesforce/connect.ts
@@ -35,6 +35,7 @@ export default class Connect extends Command {
     ({body: connection} = await this.applinkClient.post<AppLink.SalesforceConnection>(
       `/addons/${this.addonId}/connections/salesforce`,
       {
+        headers: {authorization: `Bearer ${this._applinkToken}`},
         body: {
           login_url: loginUrl,
           org_name: orgName,

--- a/src/commands/salesforce/disconnect.ts
+++ b/src/commands/salesforce/disconnect.ts
@@ -39,7 +39,9 @@ export default class Disconnect extends Command {
 
     try {
       ({body: connection} = await this.applinkClient.delete<AppLink.SalesforceConnection>(
-        `/addons/${this.addonId}/connections/${orgName}`
+        `/addons/${this.addonId}/connections/${orgName}`, {
+          headers: {authorization: `Bearer ${this._applinkToken}`},
+        }
       ))
     } catch (error) {
       const connErr = error as ConnectionError

--- a/src/commands/salesforce/import.ts
+++ b/src/commands/salesforce/import.ts
@@ -46,6 +46,7 @@ export default class Import extends Command {
     const {body: importRes} = await this.applinkClient.post<AppLink.AppImport>(
       `/addons/${this.addonId}/connections/salesforce/${orgName}/app_imports`,
       {
+        headers: {authorization: `Bearer ${this._applinkToken}`},
         body: {
           client_name: clientName,
           api_spec: encodedSpec,

--- a/src/lib/base.ts
+++ b/src/lib/base.ts
@@ -9,6 +9,7 @@ export default abstract class extends Command {
   private _applink!: APIClient
   private _addonId!: string
   _addonName!: string
+  _applinkToken!: string
 
   /**
    * Remove this once we've migrated to new default applink name
@@ -111,12 +112,12 @@ export default abstract class extends Command {
     client.defaults.host = baseUrl.hostname
     client.defaults.headers = {
       ...this.heroku.defaults.headers,
-      authorization: `Bearer ${applinkToken}`,
       accept: 'application/json',
       'user-agent': `heroku-cli-plugin-applink/${this.config.version} ${this.config.platform}`,
       'x-app-uuid': applinkAddon?.app?.id || '',
       'x-addon-sso': encodedSSO,
     }
+    this._applinkToken = applinkToken
     this._addonId = applinkAddon.id || ''
     this._addonName = applinkAddon.name || ''
     this._applink = client


### PR DESCRIPTION
<!--
When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`).

Examples:

`feat: add growl notification to spaces:wait`

`fix: handle special characters in app names`

`chore: refactor tests`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->

## Description

A bug was discovered yesterday wherein the authorization header was not being set with the correct token for calls to the AppLink API. We weren't aware since in the DEBUG output this token is redacted.

Before the fix, you can see here that the token being sent is actually the user's Heroku token (beginning with the letters "HRKU"), not the token saved as a config var for the AppLink add-on:
<img width="257" alt="Screenshot 2025-05-08 at 10 15 07 AM" src="https://github.com/user-attachments/assets/c2f4246e-660e-498d-a68e-943b0fc7bf4d" />

After the fix, you can see that the AppLink add-on token is being correctly applied to the authorization header:
<img width="223" alt="Screenshot 2025-05-08 at 10 52 27 AM" src="https://github.com/user-attachments/assets/f7f80cab-d45d-4931-89a3-42489bb1eed2" />

The problem is that we were trying to set the authorization header in the `base.ts` file as part of the `configureAppLinkClient` function. However, the api-client in heroku-cli-command does not read those default headers and was [re-setting the authorization header](https://github.com/heroku/heroku-cli-command/blob/369c860d645b2fdaea6ace2de05101bd04db3223/src/api-client.ts#L194-L196) because no "authorization" option was present in the `opts` object. What this means is that, for our plugins that need to call alternate APIs, if we use the api-client from heroku-cli-command, we are going to have to attach the authorization header to each alternate API call, instead of trying to set it in the base command class.

## Testing

**Notes**: Calls to the AppLink API are returning 500 errors right now. This has nothing to do with the auth token and you should be able to see the correct token being applied, even if they command doesn't work

1. Checkout this branch and run `yarn`
2. Open the lib/http.js file inside the http-call package in your node_modules
3. Comment out lines 301 and 302. This should remove the redaction of the authorization header in the debug logs.
4. Run the command `DEBUG=* ./bin/run applink:authorizations -a k80-test-private --addon applink-triangular-48479`
5. You should be able to see that the token in the authorization header for the call to the AppLink API no longer begins with the letters `HRKU`
6. Reset the commented lines in the lib/http.js file.
