### PR TITLE
fix: add auth headers to remaining applink api calls

### DIFF
--- a/src/commands/datacloud/connect.ts
+++ b/src/commands/datacloud/connect.ts
@@ -80,7 +80,9 @@ export default class Connect extends Command {
       });
 
       ({body: connection} = await this.applinkClient.get<AppLink.DataCloudConnection>(
-        `/addons/${this.addonId}/connections/${id}`,
+        `/addons/${this.addonId}/connections/${id}`, {
+          headers: {authorization: `Bearer ${this._applinkToken}`},
+        }
       ));
 
       ({status, error} = connection)

--- a/src/commands/datacloud/data-action-target/create.ts
+++ b/src/commands/datacloud/data-action-target/create.ts
@@ -68,6 +68,9 @@ export default class Create extends Command {
 
       ({body: createStatus} = await this.applinkClient.get<AppLink.DataActionTargetCreate>(
         `/addons/${this.addonId}/connections/datacloud/${orgName}/data_action_targets/${apiName}`,
+        {
+          headers: {authorization: `Bearer ${this._applinkToken}`},
+        }
       ))
 
       status = createStatus.status

--- a/src/commands/salesforce/authorize.ts
+++ b/src/commands/salesforce/authorize.ts
@@ -81,6 +81,9 @@ export default class Authorize extends Command {
 
       ({body: authorization} = await this.applinkClient.get<AppLink.Authorization>(
         `/addons/${this.addonId}/authorizations/${id}`,
+        {
+          headers: {authorization: `Bearer ${this._applinkToken}`},
+        }
       ));
 
       ({status, error} = authorization)

--- a/src/commands/salesforce/connect.ts
+++ b/src/commands/salesforce/connect.ts
@@ -81,6 +81,9 @@ export default class Connect extends Command {
 
       ({body: connection} = await this.applinkClient.get<AppLink.SalesforceConnection>(
         `/addons/${this.addonId}/connections/${id}`,
+        {
+          headers: {authorization: `Bearer ${this._applinkToken}`},
+        }
       ));
 
       ({status, error} = connection)

--- a/src/commands/salesforce/import.ts
+++ b/src/commands/salesforce/import.ts
@@ -63,6 +63,9 @@ export default class Import extends Command {
 
       ({body: importStatus} = await this.applinkClient.get<AppLink.AppImport>(
         `/addons/${this.addonId}/connections/salesforce/${orgName}/app_imports/${clientName}`,
+        {
+          headers: {authorization: `Bearer ${this._applinkToken}`},
+        }
       ))
 
       status = importStatus.status


### PR DESCRIPTION
<!--
When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`).

Examples:

`feat: add growl notification to spaces:wait`

`fix: handle special characters in app names`

`chore: refactor tests`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->

## Description

[WI](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002EAVoNYAX/view)

Adds authorization headers for a few AppLink API requests that I missed the first time.

## Testing

**Notes**: N/A

1. Passing CI is fine
