### PR TITLE
refactor: update applink:authorizations:info and fix --addon bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ _See code: [src/commands/applink/authorizations/index.ts](https://github.com/her
 
 ## `heroku applink:authorizations:info DEVELOPER_NAME`
 
-shows info for a Heroku AppLink authorized user
+show info for a Heroku AppLink authorized user
 
 ```
 USAGE
@@ -76,7 +76,7 @@ FLAGS
       --addon=<value>   unique name or ID of an AppLink add-on
 
 DESCRIPTION
-  shows info for a Heroku AppLink authorized user
+  show info for a Heroku AppLink authorized user
 ```
 
 _See code: [src/commands/applink/authorizations/info.ts](https://github.com/heroku/heroku-cli-plugin-applink/blob/v0.0.11/src/commands/applink/authorizations/info.ts)_

--- a/src/commands/applink/authorizations/info.ts
+++ b/src/commands/applink/authorizations/info.ts
@@ -6,7 +6,7 @@ import {Args, ux} from '@oclif/core'
 import {humanize} from '../../../lib/helpers'
 
 export default class Info extends Command {
-  static description = 'shows info for a Heroku AppLink authorized user'
+  static description = 'show info for a Heroku AppLink authorized user'
 
   static flags = {
     addon: flags.string({description: 'unique name or ID of an AppLink add-on'}),
@@ -20,10 +20,10 @@ export default class Info extends Command {
 
   public async run(): Promise<void> {
     const {flags, args} = await this.parse(Info)
-    const {app} = flags
+    const {app, addon} = flags
     const {developer_name: developerName} = args
 
-    await this.configureAppLinkClient(app)
+    await this.configureAppLinkClient(app, addon)
     let authorization: AppLink.Authorization
     try {
       ({body: authorization} = await this.applinkClient.get<AppLink.Authorization>(
@@ -45,7 +45,7 @@ export default class Info extends Command {
       ID: authorization.id,
       'Instance URL': authorization.org.instance_url,
       'Org ID': authorization.org.id,
-      'Developer Name': authorization.org.developer_name,
+      Username: authorization.org.username,
       Status: humanize(authorization.status),
       App: app,
       Type: humanize(AppLink.adjustOrgType(authorization.org.type)),

--- a/src/lib/applink/types.ts
+++ b/src/lib/applink/types.ts
@@ -6,6 +6,7 @@ interface BaseOrg {
   readonly instance_url?: string | null
   readonly 'type': 'SalesforceOrg' | 'DataCloudOrg',
   readonly username?: string | null
+  readonly user_id?: string | null
 }
 
 interface AuthorizationOrg extends BaseOrg {

--- a/test/commands/applink/authorizations/info.test.ts
+++ b/test/commands/applink/authorizations/info.test.ts
@@ -55,7 +55,6 @@ describe('applink:authorizations:info', function () {
       App:              my-app
       Created By:       user@example.com
       Created Date:     2021-01-01T00:00:00Z
-      Developer Name:   my-developer-name
       ID:               5551fe92-c2fb-4ef7-be43-9d927d9a5c53
       Instance URL:     https://dsg000007a3bca84.test1.my.pc-rnd.salesforce.com
       Last Modified:    2021-01-01T00:00:00Z
@@ -63,6 +62,7 @@ describe('applink:authorizations:info', function () {
       Org ID:           00DSG000007a3BcA84
       Status:           Connected
       Type:             Salesforce Org
+      Username:         admin@applink.org
     `)
     expect(stderr.output).to.equal('')
   })

--- a/test/helpers/fixtures.ts
+++ b/test/helpers/fixtures.ts
@@ -278,6 +278,7 @@ export const authorization_connected: AppLink.Authorization = {
     developer_name: 'my-developer-name',
     type: 'SalesforceOrg',
     username: 'admin@applink.org',
+    user_id: 'user_id',
   },
   created_by: 'user@example.com',
   last_modified_by: 'user@example.com',


### PR DESCRIPTION
<!--
When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`).

Examples:

`feat: add growl notification to spaces:wait`

`fix: handle special characters in app names`

`chore: refactor tests`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->

## Description

[WI](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002EekXjYAJ/view)

Fixes a bug with the `applink:authorizations:info` command where the user would be asked to specify an add-on using the `--addon` flag even after they'd already done so. This PR also updates the `applink:authorizations:info` command to the current requirements in the [commands design doc](https://docs.google.com/document/d/1FlfyCMiTHXMhrOpJs9R86Y9B2wmNE0abzdagFtV2dMM/edit?tab=t.0#heading=h.alwpgrrg63kf) and the [API spec doc](https://docs.google.com/document/d/1duFS1OJ_vRww4h_PZl0iCLjcFdx1qmIuvQCPol3PgJM/edit?tab=t.d4ogbhifno4m#heading=h.jbokm910jur3).

## Testing

**Notes**: You'll need to test this against the app `k80-test-private`. I was unable to create any new authorizations this morning and that app already has multiple AppLink add-ons and one of them has a valid authorization.

1. Checkout this branch and run `yarn`
2. Run `HEROKU_APPLINK_ADDON='heroku-applink-staging' ./bin/run applink:authorizations:info auth1 -a k80-test-private --addon applink-staging-fitted-50424`.
    - You will get a connection not found error, but you should not get an error asking you to specify an add-on.
