### PR TITLE
fix: Update authorization statuses

### DIFF
--- a/src/commands/salesforce/authorize.ts
+++ b/src/commands/salesforce/authorize.ts
@@ -94,7 +94,7 @@ export default class Authorize extends Command {
 
     ux.action.stop(humanize(status))
 
-    if (status !== 'connected') {
+    if (status !== 'authorized') {
       ux.error(
         error === undefined
           ? humanize(status)
@@ -108,6 +108,6 @@ export default class Authorize extends Command {
   }
 
   protected isPendingStatus(status: string): boolean {
-    return status !== 'connected' && status !== 'authentication_failed' && status !== 'connection_failed' && status !== 'disconnected'
+    return status !== 'authorized' && status !== 'disconnected'
   }
 }

--- a/src/lib/applink/types.ts
+++ b/src/lib/applink/types.ts
@@ -79,6 +79,7 @@ export type ConnectionError = {
 }
 
 export type ConnectionStatus = 'pending' | 'authenticating' | 'authenticated' | 'authentication_failed' | 'connecting' | 'connected' | 'connection_failed' | 'disconnecting' | 'disconnected' | 'disconnection_failed'
+export type AuthorizationStatus = 'authorized' | 'authorizing' | 'disconnected'
 
 /**
  * An app publish process.
@@ -123,7 +124,7 @@ export type DataActionTargetCreate = {
  */
 export type Authorization = {
   readonly id: string
-  readonly status: ConnectionStatus
+  readonly status: AuthorizationStatus
   readonly redirect_uri: string
   readonly created_at: string
   readonly last_modified_at: string,

--- a/test/commands/applink/authorizations/index.test.ts
+++ b/test/commands/applink/authorizations/index.test.ts
@@ -71,10 +71,10 @@ describe('applink:authorizations', function () {
         expect(stripAnsi(stdout.output)).to.equal(heredoc`
           === Heroku AppLink authorizations for app my-app
   
-           Type           Add-On                        Developer Name      Status    
-           ────────────── ───────────────────────────── ─────────────────── ───────── 
-           Salesforce Org heroku-applink-vertical-01234 my-developer-name   Connected 
-           Salesforce Org heroku-applink-vertical-01234 my-developer-name-2 Connected 
+           Type           Add-On                        Developer Name      Status     
+           ────────────── ───────────────────────────── ─────────────────── ────────── 
+           Salesforce Org heroku-applink-vertical-01234 my-developer-name   Authorized 
+           Salesforce Org heroku-applink-vertical-01234 my-developer-name-2 Authorized 
         `)
         expect(stderr.output).to.equal('')
       })

--- a/test/commands/applink/authorizations/info.test.ts
+++ b/test/commands/applink/authorizations/info.test.ts
@@ -60,7 +60,7 @@ describe('applink:authorizations:info', function () {
       Last Modified:    2021-01-01T00:00:00Z
       Last Modified By: user@example.com
       Org ID:           00DSG000007a3BcA84
-      Status:           Connected
+      Status:           Authorized
       Type:             Salesforce Org
       Username:         admin@applink.org
     `)

--- a/test/commands/salesforce/authorize.test.ts
+++ b/test/commands/salesforce/authorize.test.ts
@@ -94,7 +94,7 @@ describe('salesforce:authorize', function () {
         expect(stripAnsi(stderr.output)).to.eq(heredoc`
           Opening browser to https://login.test1.my.pc-rnd.salesforce.com/services/oauth2/authorize
           Adding credentials to my-app as my-auth-1...
-          Adding credentials to my-app as my-auth-1... Connected
+          Adding credentials to my-app as my-auth-1... Authorized
         `)
         expect(stdout.output).to.eq('')
       })

--- a/test/helpers/fixtures.ts
+++ b/test/helpers/fixtures.ts
@@ -267,7 +267,7 @@ export const connection_record_not_found: AppLink.SalesforceConnection = {
 
 export const authorization_connected: AppLink.Authorization = {
   id: '5551fe92-c2fb-4ef7-be43-9d927d9a5c53',
-  status: 'connected',
+  status: 'authorized',
   redirect_uri: 'https://login.test1.my.pc-rnd.salesforce.com/services/oauth2/authorize',
   created_at: '2021-01-01T00:00:00Z',
   last_modified_at: '2021-01-01T00:00:00Z',
@@ -286,7 +286,7 @@ export const authorization_connected: AppLink.Authorization = {
 
 export const authorization_connected_2: AppLink.Authorization = {
   ...authorization_connected,
-  status: 'connected',
+  status: 'authorized',
   org: {
     id: '00DSG000007a3BcA84',
     instance_url: 'https://dsg000007a3bca84.test1.my.pc-rnd.salesforce.com',
@@ -298,17 +298,17 @@ export const authorization_connected_2: AppLink.Authorization = {
 
 export const authorization_pending: AppLink.Authorization = {
   ...authorization_connected,
-  status: 'pending',
+  status: 'authorizing',
 }
 
 export const authorization_authenticating: AppLink.Authorization = {
   ...authorization_connected,
-  status: 'authenticating',
+  status: 'authorizing',
 }
 
 export const authorization_connection_failed: AppLink.Authorization = {
   ...authorization_connected,
-  status: 'connection_failed',
+  status: 'disconnected',
   error: {
     id: 'org_connection_failed',
     message: 'There was a problem connecting to your org. Try again later.',


### PR DESCRIPTION
<!--
When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`).

Examples:

`feat: add growl notification to spaces:wait`

`fix: handle special characters in app names`

`chore: refactor tests`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->

## Description

[WI](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002EkwJLYAZ/view) - `[Heroku Applink - Addon] Get authorization command working`

The possible status values for authorizations are:

* `authorized`
* `authorizing`
* `disconnected`

The CLI plugin was using the connection state values. (Note: there will need to be another PR to fix the connection-related code to use "status" and status values instead of "state" and state values.)

Slack discussion: https://salesforce-internal.slack.com/archives/C06EA6CPVST/p1747782426888039?thread_ts=1747771429.803899&cid=C06EA6CPVST

## Testing

**Notes**: Replace this text with any context/setup necessary for testing or type 'N/A'.

1. There are some details here: https://salesforce-internal.slack.com/archives/C06EA6CPVST/p1747804332243039?thread_ts=1747771429.803899&cid=C06EA6CPVST

## Screenshots (if applicable)
