### PR TITLE
fix: use the correct Bearer token in `salesforce:connect:jwt`

### DIFF
--- a/src/commands/salesforce/connect/jwt.ts
+++ b/src/commands/salesforce/connect/jwt.ts
@@ -38,6 +38,7 @@ export default class JWT extends Command {
     const {body: credential} = await this.applinkClient.post<AppLink.CredsCredential>(
       `/addons/${this.addonId}/connections/salesforce/jwt`,
       {
+        headers: {authorization: `Bearer ${this._applinkToken}`},
         body: {
           alias: randomUUID(),
           connection_name: connectionName,


### PR DESCRIPTION
<!--
When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`).

Examples:

`feat: add growl notification to spaces:wait`

`fix: handle special characters in app names`

`chore: refactor tests`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->

## Description

[WI]() -- no work item yet.

The `heroku salesforce:connect:jwt` command was calling the AppLink add-on API using the context user's Heroku API token as the Bearer token. It needs to use the app's AppLink token. This update the command to use the same Authorization header as the `heroku salesforce:connect` command.

Slack thread: https://salesforce-internal.slack.com/archives/C06EA6CPVST/p1747853965687089?thread_ts=1747849210.998869&cid=C06EA6CPVST


## Testing

**Notes**: Replace this text with any context/setup necessary for testing or type 'N/A'.

1. See the thread for examples of running the `heroku salesforce:connect:jwt` command.

## Screenshots (if applicable)
