### PR TITLE
[Fix] CLI should exit automatically once salesforce:authorize is complete

### DIFF
--- a/src/commands/salesforce/authorize.ts
+++ b/src/commands/salesforce/authorize.ts
@@ -94,7 +94,7 @@ export default class Authorize extends Command {
 
     ux.action.stop(humanize(status))
 
-    if (status !== 'connected') {
+    if (status !== 'authorized') {
       ux.error(
         error === undefined
           ? humanize(status)
@@ -108,6 +108,6 @@ export default class Authorize extends Command {
   }
 
   protected isPendingStatus(status: string): boolean {
-    return status !== 'connected' && status !== 'authentication_failed' && status !== 'connection_failed' && status !== 'disconnected'
+    return status !== 'authorized' && status !== 'authentication_failed' && status !== 'connection_failed' && status !== 'disconnected'
   }
 }

--- a/src/lib/applink/types.ts
+++ b/src/lib/applink/types.ts
@@ -78,7 +78,7 @@ export type ConnectionError = {
   }
 }
 
-export type ConnectionStatus = 'pending' | 'authenticating' | 'authenticated' | 'authentication_failed' | 'connecting' | 'connected' | 'connection_failed' | 'disconnecting' | 'disconnected' | 'disconnection_failed'
+export type ConnectionStatus = `authorized` |'pending' | 'authenticating' | 'authenticated' | 'authentication_failed' | 'connecting' | 'connected' | 'connection_failed' | 'disconnecting' | 'disconnected' | 'disconnection_failed'
 
 /**
  * An app publish process.


### PR DESCRIPTION
## Description

[WI](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002ErpbDYAR/view)

We were facing issues with salesforce:authorize where the command used to get stuck in CLI even when the command is complete.
Ref: https://salesforce-internal.slack.com/archives/C08T46L10FP/p1747922138399289?thread_ts=1747919298.471269&cid=C08T46L10FP

## Testing


1. yarn build
2. test the command using the bin directly like
```
HEROKU_APPLINK_ADDON=heroku-applink-staging ./bin/run salesforce:authorize akoul4 -a akoul-public-us --addon applink-staging-dimensional-15002 --login-url https://login.test1.pc-rnd.salesforce.com
```

## Screenshots (if applicable)

#### Before
<img width="1020" alt="image" src="https://github.com/user-attachments/assets/5d238529-4509-49b9-9fef-e10377497709" />

#### After
<img width="622" alt="image" src="https://github.com/user-attachments/assets/8100f3d0-1d56-4a2b-a4e8-86a11cb165ef" />

