### PR TITLE
chore: update type for datacloud:data-action-target:create

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ create a Data Cloud data action target for a Heroku app
 
 ```
 USAGE
-  $ heroku datacloud:data-action-target:create LABEL -a <value> -o <value> -p <value> [--addon <value>] [-n <value>] [-t WebHook] [-r
+  $ heroku datacloud:data-action-target:create LABEL -a <value> -o <value> -p <value> [--addon <value>] [-n <value>] [-t webhook] [-r
     <value>]
 
 ARGUMENTS
@@ -171,8 +171,8 @@ FLAGS
   -p, --target-api-path=<value>  (required) API path for the data action target excluding app URL, eg "/" or
                                  "/handleDataCloudDataChangeEvent"
   -r, --remote=<value>           git remote of app to use
-  -t, --type=<option>            [default: WebHook] Data action target type
-                                 <options: WebHook>
+  -t, --type=<option>            [default: webhook] Data action target type
+                                 <options: webhook>
       --addon=<value>            unique name or ID of an AppLink add-on
 
 DESCRIPTION

--- a/src/commands/datacloud/data-action-target/create.ts
+++ b/src/commands/datacloud/data-action-target/create.ts
@@ -18,7 +18,7 @@ export default class Create extends Command {
     type: flags.string({
       char: 't',
       description: 'Data action target type',
-      options: ['WebHook'], default: 'WebHook',
+      options: ['webhook'], default: 'webhook',
     }),
     remote: flags.remote(),
   }

--- a/test/commands/datacloud/data-action-taget/create.test.ts
+++ b/test/commands/datacloud/data-action-taget/create.test.ts
@@ -58,7 +58,7 @@ describe('datacloud:data-action-target:create', function () {
         '--api-name=MyDataActionTarget',
         '--connection-name=myorg',
         '--target-api-path=/handleDataCloudDataChangeEvent',
-        '--type=WebHook',
+        '--type=webhook',
       ])
 
       expect(stderr.output).to.contain('Created')

--- a/test/helpers/fixtures.ts
+++ b/test/helpers/fixtures.ts
@@ -134,7 +134,7 @@ export const datCreatePending: AppLink.DataActionTargetCreate = {
   label: 'My Data Action Target',
   status: 'pending',
   target_endpoint: '/handleDataCloudDataChangeEvent',
-  type: 'Webhook',
+  type: 'webhook',
 }
 
 export const datCreateSuccess: AppLink.DataActionTargetCreate = {


### PR DESCRIPTION
<!--
When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`).

Examples:

`feat: add growl notification to spaces:wait`

`fix: handle special characters in app names`

`chore: refactor tests`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->

## Description

[WI](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002FXKyLYAX/view)

This PR updates the `type` flag option in `datacloud:data-action-target:create` command from `WebHook` to `webhook`.

## Testing

**Notes**: N/A

1. Passing CI

## Screenshots (if applicable)
