### PR TITLE
chore: update fetch failure display

### DIFF
--- a/src/commands/applink/authorizations/index.ts
+++ b/src/commands/applink/authorizations/index.ts
@@ -39,8 +39,12 @@ export default class Index extends Command {
           header: 'Developer Name',
           get: row => row.org.developer_name,
         },
-        status: {get: row => humanize(row.status)},
+        status: {get: row => row.status === 'failed' ? color.red(humanize(row.status)) : humanize(row.status)},
       })
+
+      if (appAuthorizations.some(row => row.status === 'failed')) {
+        ux.log('Some data failed to load. See more information at <devcenter link>')
+      }
     }
   }
 }

--- a/src/commands/applink/authorizations/index.ts
+++ b/src/commands/applink/authorizations/index.ts
@@ -43,7 +43,7 @@ export default class Index extends Command {
       })
 
       if (appAuthorizations.some(row => row.status === 'failed')) {
-        ux.log('Some data failed to load. See more information at <devcenter link>')
+        ux.log('\nSome data failed to load. See more information at <devcenter link>')
       }
     }
   }

--- a/src/commands/applink/authorizations/index.ts
+++ b/src/commands/applink/authorizations/index.ts
@@ -43,7 +43,7 @@ export default class Index extends Command {
       })
 
       if (appAuthorizations.some(row => row.status === 'failed')) {
-        ux.log('\nSome data failed to load. See more information at <devcenter link>')
+        ux.log('\nYou have one or more failed authorizations. For more information on how to fix authorizations, see https://devcenter.heroku.com/articles/heroku-applink#authorization-statuses.')
       }
     }
   }

--- a/src/commands/applink/connections/index.ts
+++ b/src/commands/applink/connections/index.ts
@@ -47,7 +47,7 @@ export default class Index extends Command {
       })
 
       if (appConnections.some(row => row.status === 'failed')) {
-        ux.log('\nSome data failed to load. See more information at <devcenter link>')
+        ux.log('\nYou have one or more failed connections. For more information on how to fix connections, see https://devcenter.heroku.com/articles/heroku-applink#connection-statuses.')
       }
     }
   }

--- a/src/commands/applink/connections/index.ts
+++ b/src/commands/applink/connections/index.ts
@@ -43,8 +43,12 @@ export default class Index extends Command {
           header: 'Connection Name',
           get: row => row.org.connection_name,
         },
-        status: {get: row => humanize(row.status)},
+        status: {get: row => row.status === 'failed' ? color.red(humanize(row.status)) : humanize(row.status)},
       })
+
+      if (appConnections.some(row => row.status === 'failed')) {
+        ux.log('Some data failed to load. See more information at <devcenter link>')
+      }
     }
   }
 }

--- a/src/commands/applink/connections/index.ts
+++ b/src/commands/applink/connections/index.ts
@@ -47,7 +47,7 @@ export default class Index extends Command {
       })
 
       if (appConnections.some(row => row.status === 'failed')) {
-        ux.log('Some data failed to load. See more information at <devcenter link>')
+        ux.log('\nSome data failed to load. See more information at <devcenter link>')
       }
     }
   }

--- a/src/commands/datacloud/connect.ts
+++ b/src/commands/datacloud/connect.ts
@@ -107,6 +107,6 @@ export default class Connect extends Command {
   }
 
   protected isPendingStatus(status: string): boolean {
-    return status !== 'connected' && status !== 'error' && status !== 'disconnected'
+    return status !== 'connected' && status !== 'failed' && status !== 'disconnected'
   }
 }

--- a/src/commands/salesforce/connect/index.ts
+++ b/src/commands/salesforce/connect/index.ts
@@ -108,6 +108,6 @@ export default class Connect extends Command {
   }
 
   protected isPendingStatus(status: string): boolean {
-    return status !== 'connected' && status !== 'error' && status !== 'disconnected'
+    return status !== 'connected' && status !== 'failed' && status !== 'disconnected'
   }
 }

--- a/src/lib/applink/types.ts
+++ b/src/lib/applink/types.ts
@@ -91,8 +91,8 @@ export type ConnectionError = {
   }
 }
 
-export type ConnectionStatus = 'connecting' | 'connected' | 'disconnecting' | 'disconnected' | 'error'
-export type AuthorizationStatus = 'authorized' | 'authorizing' | 'disconnected' | 'error'
+export type ConnectionStatus = 'connecting' | 'connected' | 'disconnecting' | 'disconnected' | 'failed'
+export type AuthorizationStatus = 'authorized' | 'authorizing' | 'disconnected' | 'failed'
 
 /**
  * An app publish process.

--- a/test/commands/applink/authorizations/index.test.ts
+++ b/test/commands/applink/authorizations/index.test.ts
@@ -9,10 +9,11 @@ import {
   addon,
   authorization_connected,
   authorization_connected_2,
+  authorization_connected_3_failed,
   sso_response,
 } from '../../../helpers/fixtures'
 
-describe('applink:authorizations', function () {
+describe.only('applink:authorizations', function () {
   let api: nock.Scope
   let applinkApi: nock.Scope
   const {env} = process
@@ -76,6 +77,31 @@ describe('applink:authorizations', function () {
            Salesforce Org heroku-applink-vertical-01234 my-developer-name   Authorized 
            Salesforce Org heroku-applink-vertical-01234 my-developer-name-2 Authorized 
         `)
+        expect(stderr.output).to.equal('')
+      })
+    })
+
+    context('when Heroku AppLink authorizations fails to load', function () {
+      it('shows failed authorization and warning message', async function () {
+        applinkApi
+          .get('/addons/01234567-89ab-cdef-0123-456789abcdef/authorizations')
+          .reply(200, [authorization_connected, authorization_connected_2, authorization_connected_3_failed])
+
+        await runCommand(Cmd, [
+          '--app=my-app',
+        ])
+
+        expect(stripAnsi(stdout.output)).to.equal(heredoc`
+=== Heroku AppLink authorizations for app my-app
+
+ Type           Add-On                        Developer Name      Status     
+ ────────────── ───────────────────────────── ─────────────────── ────────── 
+ Salesforce Org heroku-applink-vertical-01234 my-developer-name   Authorized 
+ Salesforce Org heroku-applink-vertical-01234 my-developer-name-2 Authorized 
+ Salesforce Org heroku-applink-vertical-01234 my-developer-name-3 Failed     
+
+Some data failed to load. See more information at <devcenter link>
+          `)
         expect(stderr.output).to.equal('')
       })
     })

--- a/test/commands/applink/authorizations/index.test.ts
+++ b/test/commands/applink/authorizations/index.test.ts
@@ -100,7 +100,7 @@ describe('applink:authorizations', function () {
  Salesforce Org heroku-applink-vertical-01234 my-developer-name-2 Authorized 
  Salesforce Org heroku-applink-vertical-01234 my-developer-name-3 Failed     
 
-Some data failed to load. See more information at <devcenter link>
+You have one or more failed authorizations. For more information on how to fix authorizations, see https://devcenter.heroku.com/articles/heroku-applink#authorization-statuses.
           `)
         expect(stderr.output).to.equal('')
       })

--- a/test/commands/applink/authorizations/index.test.ts
+++ b/test/commands/applink/authorizations/index.test.ts
@@ -13,7 +13,7 @@ import {
   sso_response,
 } from '../../../helpers/fixtures'
 
-describe.only('applink:authorizations', function () {
+describe('applink:authorizations', function () {
   let api: nock.Scope
   let applinkApi: nock.Scope
   const {env} = process

--- a/test/commands/applink/connections/index.test.ts
+++ b/test/commands/applink/connections/index.test.ts
@@ -13,7 +13,7 @@ import {
   sso_response,
 } from '../../../helpers/fixtures'
 
-describe.only('applink:connections', function () {
+describe('applink:connections', function () {
   let api: nock.Scope
   let applinkApi: nock.Scope
   const {env} = process

--- a/test/commands/applink/connections/index.test.ts
+++ b/test/commands/applink/connections/index.test.ts
@@ -100,7 +100,7 @@ describe('applink:connections', function () {
            heroku-applink-vertical-01234 Salesforce Org my-org-2        Connected 
            heroku-applink-vertical-01234 Salesforce Org my-org-3        Failed    
 
-          Some data failed to load. See more information at <devcenter link>
+          You have one or more failed connections. For more information on how to fix connections, see https://devcenter.heroku.com/articles/heroku-applink#connection-statuses.
         `)
         expect(stderr.output).to.equal('')
       })

--- a/test/commands/applink/connections/index.test.ts
+++ b/test/commands/applink/connections/index.test.ts
@@ -9,10 +9,11 @@ import {
   addon,
   connection1,
   connection2_connected,
+  connection3_connected_failed,
   sso_response,
 } from '../../../helpers/fixtures'
 
-describe('applink:connections', function () {
+describe.only('applink:connections', function () {
   let api: nock.Scope
   let applinkApi: nock.Scope
   const {env} = process
@@ -75,6 +76,31 @@ describe('applink:connections', function () {
            ───────────────────────────── ────────────── ─────────────── ───────── 
            heroku-applink-vertical-01234 Salesforce Org my-org-1        Connected 
            heroku-applink-vertical-01234 Salesforce Org my-org-2        Connected 
+        `)
+        expect(stderr.output).to.equal('')
+      })
+    })
+
+    context('when Heroku AppLink connections fails to load', function () {
+      it('shows failed connection and warning message', async function () {
+        applinkApi
+          .get('/addons/01234567-89ab-cdef-0123-456789abcdef/connections')
+          .reply(200, [connection1, connection2_connected, connection3_connected_failed])
+
+        await runCommand(Cmd, [
+          '--app=my-app',
+        ])
+
+        expect(stripAnsi(stdout.output)).to.equal(heredoc`
+          === Heroku AppLink connections for add-on heroku-applink-vertical-01234 on app my-app
+        
+           Add-On                        Type           Connection Name Status    
+           ───────────────────────────── ────────────── ─────────────── ───────── 
+           heroku-applink-vertical-01234 Salesforce Org my-org-1        Connected 
+           heroku-applink-vertical-01234 Salesforce Org my-org-2        Connected 
+           heroku-applink-vertical-01234 Salesforce Org my-org-3        Failed    
+
+          Some data failed to load. See more information at <devcenter link>
         `)
         expect(stderr.output).to.equal('')
       })

--- a/test/commands/datacloud/disconnect.test.ts
+++ b/test/commands/datacloud/disconnect.test.ts
@@ -55,7 +55,7 @@ describe('datacloud:disconnect', function () {
         ])
       } catch (error: unknown) {
         const {message, oclif} = error as CLIError
-        expect(stripAnsi(message)).to.equal('Error')
+        expect(stripAnsi(message)).to.equal('Failed')
         expect(oclif.exit).to.equal(1)
       }
     })

--- a/test/commands/salesforce/connect/jwt.test.ts
+++ b/test/commands/salesforce/connect/jwt.test.ts
@@ -74,7 +74,7 @@ describe('salesforce:connect:jwt', function () {
 
     expect(stripAnsi(stderr.output)).to.eq(heredoc`
       Adding credentials for test-username to my-app as my-connection-1...
-      Adding credentials for test-username to my-app as my-connection-1... Error
+      Adding credentials for test-username to my-app as my-connection-1... Failed
     `)
   })
 })

--- a/test/helpers/fixtures.ts
+++ b/test/helpers/fixtures.ts
@@ -95,6 +95,23 @@ export const connection2_connected: AppLink.SalesforceConnection = {
   last_modified_by: 'user@example.com',
 }
 
+export const connection3_connected_failed: AppLink.SalesforceConnection = {
+  id: '5551fe92-c2fb-4ef7-be43-9d927d9a5c53',
+  org: {
+    id: '00DSG000007a3BcA84',
+    instance_url: 'https://dsg000007a3bca84.test1.my.pc-rnd.salesforce.com',
+    connection_name: 'my-org-3',
+    type: 'SalesforceOrg',
+    username: 'admin@applink.org',
+  },
+  status: 'failed',
+  created_via_app: 'my-app',
+  created_at: '2021-01-01T00:00:00Z',
+  last_modified_at: '2021-01-01T00:00:00Z',
+  created_by: 'user@example.com',
+  last_modified_by: 'user@example.com',
+}
+
 export const connection2_failed: AppLink.SalesforceConnection = {
   error: {
     id: 'org_connection_failed',
@@ -108,7 +125,7 @@ export const connection2_failed: AppLink.SalesforceConnection = {
     type: 'SalesforceOrg',
     username: 'admin@applink.org',
   },
-  status: 'error',
+  status: 'failed',
   created_via_app: 'my-app',
   created_at: '2021-01-01T00:00:00Z',
   last_modified_at: '2021-01-01T00:00:00Z',
@@ -229,7 +246,7 @@ export const connection4_failed: AppLink.DataCloudConnection = {
     message: 'There was a problem connecting your org. Try again later.',
   },
   id: '339b373a-5d0c-4056-bfdd-47a06b79f112',
-  status: 'error',
+  status: 'failed',
   created_via_app: 'my-app',
   created_at: '2021-01-01T00:00:00Z',
   last_modified_at: '2021-01-01T00:00:00Z',
@@ -280,7 +297,7 @@ export const connection5_disconnection_failed: AppLink.DataCloudConnection = {
     username: 'admin@applink.org',
   },
   id: '339b373a-5d0c-4056-bfdd-47a06b79f112',
-  status: 'error',
+  status: 'failed',
   created_via_app: 'my-app',
   created_at: '2021-01-01T00:00:00Z',
   last_modified_at: '2021-01-01T00:00:00Z',
@@ -308,7 +325,7 @@ export const connection_record_not_found: AppLink.SalesforceConnection = {
     type: 'SalesforceOrg',
     username: 'admin@applink.org',
   },
-  status: 'error',
+  status: 'failed',
   created_via_app: 'my-app',
   created_at: '2021-01-01T00:00:00Z',
   last_modified_at: '2021-01-01T00:00:00Z',
@@ -343,6 +360,18 @@ export const authorization_connected_2: AppLink.Authorization = {
     id: '00DSG000007a3BcA84',
     instance_url: 'https://dsg000007a3bca84.test1.my.pc-rnd.salesforce.com',
     developer_name: 'my-developer-name-2',
+    type: 'SalesforceOrg',
+    username: 'admin@applink.org',
+  },
+}
+
+export const authorization_connected_3_failed: AppLink.Authorization = {
+  ...authorization_connected,
+  status: 'failed',
+  org: {
+    id: '00DSG000007a3BcA84',
+    instance_url: 'https://dsg000007a3bca84.test1.my.pc-rnd.salesforce.com',
+    developer_name: 'my-developer-name-3',
     type: 'SalesforceOrg',
     username: 'admin@applink.org',
   },
@@ -445,5 +474,5 @@ export const credential_id_connected: AppLink.CredsCredential = {
 
 export const credential_id_failed: AppLink.CredsCredential = {
   ...credential_id_connected,
-  status: 'error',
+  status: 'failed',
 }


### PR DESCRIPTION
<!--
When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`).

Examples:

`feat: add growl notification to spaces:wait`

`fix: handle special characters in app names`

`chore: refactor tests`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->

## Description

[WI](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002FXlVKYA1/view)

This PR updates the `applink:authorizations` and `applink:connections` commands to surface the updated `Status` state from `Error` to `Failed`. This is for when fetching a particular authorization/connection fails. The text color for `Failed` will be red per design's request. In addition, a message linking to further documentation of the issue is surfaced whenever a failed connection is present.

**Note:** A follow up PR with the prod devcenter link will need to be added prior to GA. [WI](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002FcJfiYAF/view)

## Testing

**Notes**: N/A

1. Passing CI

## Screenshots (if applicable)
