### PR TITLE
fix: take add-on attachments into consideration when getting config vars

### DIFF
--- a/src/lib/base.ts
+++ b/src/lib/base.ts
@@ -84,7 +84,7 @@ export default abstract class extends Command {
       )
     }
 
-    const addonAttachment = addonAttachments.find(a => a.addon.id === applinkAddon.id)
+    const addonAttachment = addonAttachments.find(attachment => attachment.addon.id === applinkAddon.id)
     const {apiUrl, applinkToken} = this.getConfigVars(addonAttachment!, configVars)
 
     if (!apiUrl || !applinkToken) {

--- a/src/lib/base.ts
+++ b/src/lib/base.ts
@@ -33,11 +33,11 @@ export default abstract class extends Command {
     return this._addonId || ''
   }
 
-  protected getConfigVars(addon: Heroku.AddOn, configVars: Heroku.ConfigVars): {apiUrl: string, applinkToken: string} {
-    const apiConfigVarName = addon.config_vars?.find(v => v.endsWith('API_URL'))
-    const tokenConfigVarName = addon.config_vars?.find(v => v.endsWith('TOKEN'))
-    const apiUrl = apiConfigVarName ? configVars[apiConfigVarName] : ''
-    const applinkToken = tokenConfigVarName ? configVars[tokenConfigVarName] : ''
+  protected getConfigVars(addonAttachment: Heroku.AddOnAttachment, configVars: Heroku.ConfigVars): {apiUrl: string, applinkToken: string} {
+    const apiConfigVarName = addonAttachment.name + '_API_URL'
+    const tokenConfigVarName = addonAttachment.name + '_TOKEN'
+    const apiUrl = configVars[apiConfigVarName]
+    const applinkToken = configVars[tokenConfigVarName]
     return {apiUrl, applinkToken}
   }
 
@@ -47,15 +47,16 @@ export default abstract class extends Command {
 
     const appInfoRequest = this.heroku.get<Heroku.App>(`/apps/${app}`)
     const addonsRequest = this.heroku.get<Required<Heroku.AddOn>[]>(`/apps/${app}/addons`)
+    const addonAttachmentsRequest = this.heroku.get<Required<Heroku.AddOnAttachment>[]>(`/apps/${app}/addon-attachments`)
     const configVarsRequest = this.heroku.get<Heroku.ConfigVars>(`/apps/${app}/config-vars`)
-    const [{body: appInfo}, {body: addons}, {body: configVars}] = await Promise.all([appInfoRequest, addonsRequest, configVarsRequest])
+    const [{body: appInfo}, {body: addons}, {body: addonAttachments}, {body: configVars}] = await Promise.all([appInfoRequest, addonsRequest, addonAttachmentsRequest, configVarsRequest])
     const applinkAddons = addons.filter(addon => addon.addon_service.name === this.addonServiceSlug)
     let applinkAddon: Heroku.AddOn | undefined
 
     if (applinkAddons.length === 0) {
       ux.error(
         heredoc`
-          AppLink add-on isn’t present on ${color.app(app)}.
+          AppLink add-on isn't present on ${color.app(app)}.
           Install the add-on using ${color.cmd(`heroku addons:create ${this.addonServiceSlug} -a ${app}`)}.
         `,
         {exit: 1}
@@ -83,12 +84,13 @@ export default abstract class extends Command {
       )
     }
 
-    const {apiUrl, applinkToken} = this.getConfigVars(applinkAddon, configVars)
+    const addonAttachment = addonAttachments.find(a => a.addon.id === applinkAddon.id)
+    const {apiUrl, applinkToken} = this.getConfigVars(addonAttachment!, configVars)
 
     if (!apiUrl || !applinkToken) {
       ux.error(
         heredoc`
-          AppLink add-on isn’t fully provisioned on ${color.app(app)}.
+          AppLink add-on isn't fully provisioned on ${color.app(app)}.
           Wait for the add-on to finish provisioning with ${color.cmd(`heroku addons:wait ${applinkAddon.name} -a ${app}`)}.
         `,
         {exit: 1}

--- a/test/commands/applink/authorizations/index.test.ts
+++ b/test/commands/applink/authorizations/index.test.ts
@@ -12,6 +12,7 @@ import {
   authorization_connected_3_failed,
   sso_response,
   app,
+  addonAttachment,
 } from '../../../helpers/fixtures'
 
 describe('applink:authorizations', function () {
@@ -38,6 +39,8 @@ describe('applink:authorizations', function () {
         .reply(200, app)
         .get('/apps/my-app/addons')
         .reply(200, [addon])
+        .get('/apps/my-app/addon-attachments')
+        .reply(200, [addonAttachment])
         .get('/apps/my-app/config-vars')
         .reply(200, {
           HEROKU_APPLINK_API_URL: 'https://applink-api.heroku.com/addons/01234567-89ab-cdef-0123-456789abcdef',

--- a/test/commands/applink/authorizations/info.test.ts
+++ b/test/commands/applink/authorizations/info.test.ts
@@ -11,6 +11,7 @@ import {
   authorization_not_found,
   sso_response,
   app,
+  addonAttachment,
 } from '../../../helpers/fixtures'
 import {CLIError} from '@oclif/core/lib/errors'
 
@@ -26,6 +27,8 @@ describe('applink:authorizations:info', function () {
       .reply(200, app)
       .get('/apps/my-app/addons')
       .reply(200, [addon])
+      .get('/apps/my-app/addon-attachments')
+      .reply(200, [addonAttachment])
       .get('/apps/my-app/config-vars')
       .reply(200, {
         HEROKU_APPLINK_API_URL: 'https://applink-api.heroku.com/addons/01234567-89ab-cdef-0123-456789abcdef',

--- a/test/commands/applink/connections/index.test.ts
+++ b/test/commands/applink/connections/index.test.ts
@@ -12,6 +12,7 @@ import {
   connection3_connected_failed,
   sso_response,
   app,
+  addonAttachment,
 } from '../../../helpers/fixtures'
 
 describe('applink:connections', function () {
@@ -38,6 +39,8 @@ describe('applink:connections', function () {
         .reply(200, app)
         .get('/apps/my-app/addons')
         .reply(200, [addon])
+        .get('/apps/my-app/addon-attachments')
+        .reply(200, [addonAttachment])
         .get('/apps/my-app/config-vars')
         .reply(200, {
           HEROKU_APPLINK_API_URL: 'https://applink-api.heroku.com/addons/01234567-89ab-cdef-0123-456789abcdef',

--- a/test/commands/applink/connections/info.test.ts
+++ b/test/commands/applink/connections/info.test.ts
@@ -11,6 +11,7 @@ import {
   connection_record_not_found,
   sso_response,
   app,
+  addonAttachment,
 } from '../../../helpers/fixtures'
 import {CLIError} from '@oclif/core/lib/errors'
 
@@ -27,6 +28,8 @@ describe('applink:connections:info', function () {
         .reply(200, app)
         .get('/apps/my-app/addons')
         .reply(200, [addon])
+        .get('/apps/my-app/addon-attachments')
+        .reply(200, [addonAttachment])
         .get('/apps/my-app/config-vars')
         .reply(200, {
           HEROKU_APPLINK_API_URL: 'https://applink-api.heroku.com/addons/01234567-89ab-cdef-0123-456789abcdef',

--- a/test/commands/datacloud/authorizations/add.test.ts
+++ b/test/commands/datacloud/authorizations/add.test.ts
@@ -15,6 +15,7 @@ import {
   authorization_disconnected,
   sso_response,
   app,
+  addonAttachment,
 } from '../../../helpers/fixtures'
 import stripAnsi from '../../../helpers/strip-ansi'
 import {CLIError} from '@oclif/core/lib/errors'
@@ -33,6 +34,8 @@ describe('datacloud:authorizations:add', function () {
       .reply(200, app)
       .get('/apps/my-app/addons')
       .reply(200, [addon])
+      .get('/apps/my-app/addon-attachments')
+      .reply(200, [addonAttachment])
       .get('/apps/my-app/config-vars')
       .reply(200, {
         HEROKU_APPLINK_API_URL: 'https://applink-api.heroku.com/addons/01234567-89ab-cdef-0123-456789abcdef',

--- a/test/commands/datacloud/authorizations/remove.test.ts
+++ b/test/commands/datacloud/authorizations/remove.test.ts
@@ -7,6 +7,7 @@ import {
   addon,
   sso_response,
   app,
+  addonAttachment,
 } from '../../../helpers/fixtures'
 import stripAnsi from '../../../helpers/strip-ansi'
 
@@ -22,6 +23,8 @@ describe('datacloud:authorizations:remove', function () {
       .reply(200, app)
       .get('/apps/my-app/addons')
       .reply(200, [addon])
+      .get('/apps/my-app/addon-attachments')
+      .reply(200, [addonAttachment])
       .get('/apps/my-app/config-vars')
       .reply(200, {
         HEROKU_APPLINK_API_URL: 'https://applink-api.heroku.com/addons/01234567-89ab-cdef-0123-456789abcdef',

--- a/test/commands/datacloud/connect.test.ts
+++ b/test/commands/datacloud/connect.test.ts
@@ -15,6 +15,7 @@ import {
   connection4_failed,
   sso_response,
   app,
+  addonAttachment,
 } from '../../helpers/fixtures'
 import stripAnsi from '../../helpers/strip-ansi'
 import {CLIError} from '@oclif/core/lib/errors'
@@ -35,6 +36,8 @@ describe('datacloud:connect', function () {
         .reply(200, app)
         .get('/apps/my-app/addons')
         .reply(200, [addon])
+        .get('/apps/my-app/addon-attachments')
+        .reply(200, [addonAttachment])
         .get('/apps/my-app/config-vars')
         .reply(200, {
           HEROKU_APPLINK_API_URL: 'https://applink-api.heroku.com/addons/01234567-89ab-cdef-0123-456789abcdef',

--- a/test/commands/datacloud/data-action-taget/create.test.ts
+++ b/test/commands/datacloud/data-action-taget/create.test.ts
@@ -10,6 +10,7 @@ import {
   datCreateFailed,
   sso_response,
   app,
+  addonAttachment,
 } from '../../../helpers/fixtures'
 import stripAnsi from '../../../helpers/strip-ansi'
 import {CLIError} from '@oclif/core/lib/errors'
@@ -27,6 +28,8 @@ describe('datacloud:data-action-target:create', function () {
         .reply(200, app)
         .get('/apps/my-app/addons')
         .reply(200, [addon])
+        .get('/apps/my-app/addon-attachments')
+        .reply(200, [addonAttachment])
         .get('/apps/my-app/config-vars')
         .reply(200, {
           HEROKU_APPLINK_API_URL: 'https://applink-api.heroku.com/addons/01234567-89ab-cdef-0123-456789abcdef',

--- a/test/commands/datacloud/disconnect.test.ts
+++ b/test/commands/datacloud/disconnect.test.ts
@@ -10,6 +10,7 @@ import {
   ConnectionError_record_not_found,
   sso_response,
   app,
+  addonAttachment,
 } from '../../helpers/fixtures'
 import {CLIError} from '@oclif/core/lib/errors'
 import stripAnsi from '../../helpers/strip-ansi'
@@ -28,6 +29,8 @@ describe('datacloud:disconnect', function () {
         .reply(200, app)
         .get('/apps/my-app/addons')
         .reply(200, [addon])
+        .get('/apps/my-app/addon-attachments')
+        .reply(200, [addonAttachment])
         .get('/apps/my-app/config-vars')
         .reply(200, {
           HEROKU_APPLINK_API_URL: 'https://applink-api.heroku.com/addons/01234567-89ab-cdef-0123-456789abcdef',

--- a/test/commands/salesforce/authorizations/add.test.ts
+++ b/test/commands/salesforce/authorizations/add.test.ts
@@ -15,6 +15,7 @@ import {
   authorization_disconnected,
   sso_response,
   app,
+  addonAttachment,
 } from '../../../helpers/fixtures'
 import stripAnsi from '../../../helpers/strip-ansi'
 import {CLIError} from '@oclif/core/lib/errors'
@@ -33,6 +34,8 @@ describe('salesforce:authorizations:add', function () {
       .reply(200, app)
       .get('/apps/my-app/addons')
       .reply(200, [addon])
+      .get('/apps/my-app/addon-attachments')
+      .reply(200, [addonAttachment])
       .get('/apps/my-app/config-vars')
       .reply(200, {
         HEROKU_APPLINK_API_URL: 'https://applink-api.heroku.com/addons/01234567-89ab-cdef-0123-456789abcdef',

--- a/test/commands/salesforce/authorizations/remove.test.ts
+++ b/test/commands/salesforce/authorizations/remove.test.ts
@@ -7,6 +7,7 @@ import {
   addon,
   sso_response,
   app,
+  addonAttachment,
 } from '../../../helpers/fixtures'
 import stripAnsi from '../../../helpers/strip-ansi'
 
@@ -22,6 +23,8 @@ describe('salesforce:authorizations:remove', function () {
       .reply(200, app)
       .get('/apps/my-app/addons')
       .reply(200, [addon])
+      .get('/apps/my-app/addon-attachments')
+      .reply(200, [addonAttachment])
       .get('/apps/my-app/config-vars')
       .reply(200, {
         HEROKU_APPLINK_API_URL: 'https://applink-api.heroku.com/addons/01234567-89ab-cdef-0123-456789abcdef',

--- a/test/commands/salesforce/connect/index.test.ts
+++ b/test/commands/salesforce/connect/index.test.ts
@@ -15,6 +15,7 @@ import {
   connection2_failed,
   sso_response,
   app,
+  addonAttachment,
 } from '../../../helpers/fixtures'
 import stripAnsi from '../../../helpers/strip-ansi'
 import {CLIError} from '@oclif/core/lib/errors'
@@ -35,6 +36,8 @@ describe('salesforce:connect', function () {
         .reply(200, app)
         .get('/apps/my-app/addons')
         .reply(200, [addon])
+        .get('/apps/my-app/addon-attachments')
+        .reply(200, [addonAttachment])
         .get('/apps/my-app/config-vars')
         .reply(200, {
           HEROKU_APPLINK_API_URL: 'https://applink-api.heroku.com/addons/01234567-89ab-cdef-0123-456789abcdef',

--- a/test/commands/salesforce/connect/jwt.test.ts
+++ b/test/commands/salesforce/connect/jwt.test.ts
@@ -11,6 +11,7 @@ import {
   credential_id_connected,
   credential_id_failed,
   app,
+  addonAttachment,
 } from '../../../helpers/fixtures'
 
 describe('salesforce:connect:jwt', function () {
@@ -25,6 +26,8 @@ describe('salesforce:connect:jwt', function () {
       .reply(200, app)
       .get('/apps/my-app/addons')
       .reply(200, [addon])
+      .get('/apps/my-app/addon-attachments')
+      .reply(200, [addonAttachment])
       .get('/apps/my-app/config-vars')
       .reply(200, {
         HEROKU_APPLINK_API_URL: 'https://applink-api.heroku.com/addons/01234567-89ab-cdef-0123-456789abcdef',

--- a/test/commands/salesforce/disconnect.test.ts
+++ b/test/commands/salesforce/disconnect.test.ts
@@ -9,6 +9,7 @@ import {
   ConnectionError_record_not_found,
   sso_response,
   app,
+  addonAttachment,
 } from '../../helpers/fixtures'
 import {CLIError} from '@oclif/core/lib/errors'
 import stripAnsi from '../../helpers/strip-ansi'
@@ -26,6 +27,8 @@ describe('salesforce:disconnect', function () {
         .reply(200, app)
         .get('/apps/my-app/addons')
         .reply(200, [addon])
+        .get('/apps/my-app/addon-attachments')
+        .reply(200, [addonAttachment])
         .get('/apps/my-app/config-vars')
         .reply(200, {
           HEROKU_APPLINK_API_URL: 'https://applink-api.heroku.com/addons/01234567-89ab-cdef-0123-456789abcdef',

--- a/test/commands/salesforce/publications.test.ts
+++ b/test/commands/salesforce/publications.test.ts
@@ -15,6 +15,7 @@ import {
   publication2,
   sso_response,
   app,
+  addonAttachment,
 } from '../../helpers/fixtures'
 import {CLIError} from '@oclif/core/lib/errors'
 
@@ -32,6 +33,8 @@ describe('salesforce:publications', function () {
       .reply(200, app)
       .get('/apps/my-app/addons')
       .reply(200, [addon])
+      .get('/apps/my-app/addon-attachments')
+      .reply(200, [addonAttachment])
       .get('/apps/my-app/config-vars')
       .reply(200, {
         HEROKU_APPLINK_API_URL: 'https://applink-api.heroku.com/addons/01234567-89ab-cdef-0123-456789abcdef',

--- a/test/commands/salesforce/publish.test.ts
+++ b/test/commands/salesforce/publish.test.ts
@@ -7,6 +7,7 @@ import {
   addon,
   sso_response,
   app,
+  addonAttachment,
 } from '../../helpers/fixtures'
 import stripAnsi from '../../helpers/strip-ansi'
 import {CLIError} from '@oclif/core/lib/errors'
@@ -25,6 +26,8 @@ describe('salesforce:publish', function () {
         .reply(200, app)
         .get('/apps/my-app/addons')
         .reply(200, [addon])
+        .get('/apps/my-app/addon-attachments')
+        .reply(200, [addonAttachment])
         .get('/apps/my-app/config-vars')
         .reply(200, {
           HEROKU_APPLINK_API_URL: 'https://applink-api.heroku.com/addons/01234567-89ab-cdef-0123-456789abcdef',

--- a/test/helpers/fixtures.ts
+++ b/test/helpers/fixtures.ts
@@ -45,6 +45,36 @@ export const addonStaging: Heroku.AddOn = {
   name: 'heroku-applink-staging-01234',
 }
 
+export const addonAttachment: Heroku.AddOnAttachment = {
+  id: '01234567-89ab-cdef-0123-456789abcdef',
+  addon: {
+    id: addon.id!,
+    name: addon.name!,
+    app,
+  },
+  name: 'HEROKU_APPLINK',
+}
+
+export const addonAttachment2: Heroku.AddOnAttachment = {
+  id: '6789abcd-ef01-2345-6789-abcdef012345',
+  addon: {
+    id: addon2.id!,
+    name: addon2.name!,
+    app: app2,
+  },
+  name: 'HEROKU_APPLINK_COBALT',
+}
+
+export const addonAttachmentStaging: Heroku.AddOnAttachment = {
+  id: '6789abcd-ef01-2345-6789-abcdef012345',
+  addon: {
+    id: addonStaging.id!,
+    name: addonStaging.name!,
+    app: app2,
+  },
+  name: 'HEROKU_APPLINK_STAGING',
+}
+
 export const connection1: AppLink.SalesforceConnection = {
   id: '51807d19-9d78-4064-9468-bcdc34611778',
   org: {

--- a/test/lib/base.test.ts
+++ b/test/lib/base.test.ts
@@ -15,6 +15,9 @@ import {
   addonStaging,
   sso_response,
   app,
+  addonAttachment,
+  addonAttachment2,
+  addonAttachmentStaging,
 } from '../helpers/fixtures'
 
 class CommandWithoutConfiguration extends BaseCommand {
@@ -90,6 +93,8 @@ describe('attempt a request using the applink API client', function () {
         .reply(200, [])
         .get('/apps/my-app/config-vars')
         .reply(200, {})
+        .get('/apps/my-app/addon-attachments')
+        .reply(200, [])
     })
 
     it('returns an error message and exits with a status of 1', async function () {
@@ -100,7 +105,7 @@ describe('attempt a request using the applink API client', function () {
       } catch (error) {
         const {message, oclif} = error as CLIError
         expect(stripAnsi(message)).to.equal(heredoc`
-          AppLink add-on isn’t present on my-app.
+          AppLink add-on isn't present on my-app.
           Install the add-on using heroku addons:create heroku-applink -a my-app.
         `)
         expect(oclif.exit).to.equal(1)
@@ -117,6 +122,8 @@ describe('attempt a request using the applink API client', function () {
         .reply(200, app)
         .get('/apps/my-app/addons')
         .reply(200, [addon])
+        .get('/apps/my-app/addon-attachments')
+        .reply(200, [addonAttachment])
         .get('/apps/my-app/config-vars')
         .reply(200, {})
     })
@@ -129,7 +136,7 @@ describe('attempt a request using the applink API client', function () {
       } catch (error) {
         const {message, oclif} = error as CLIError
         expect(stripAnsi(message)).to.equal(heredoc`
-          AppLink add-on isn’t fully provisioned on my-app.
+          AppLink add-on isn't fully provisioned on my-app.
           Wait for the add-on to finish provisioning with heroku addons:wait ${addon.name} -a my-app.
         `)
         expect(oclif.exit).to.equal(1)
@@ -146,6 +153,8 @@ describe('attempt a request using the applink API client', function () {
         .reply(200, app)
         .get('/apps/my-app/addons')
         .reply(200, [addon])
+        .get('/apps/my-app/addon-attachments')
+        .reply(200, [addonAttachment])
         .get('/apps/my-app/config-vars')
         .reply(200, {
           HEROKU_APPLINK_API_URL: 'https://applink-api.heroku.com/addons/01234567-89ab-cdef-0123-456789abcdef',
@@ -179,10 +188,12 @@ describe('attempt a request using the applink API client', function () {
         .reply(200, app)
         .get('/apps/my-app/addons')
         .reply(200, [addonStaging])
+        .get('/apps/my-app/addon-attachments')
+        .reply(200, [addonAttachmentStaging])
         .get('/apps/my-app/config-vars')
         .reply(200, {
-          HEROKU_APPLINK_API_URL: 'https://applink-api.heroku.com/addons/01234567-89ab-cdef-0123-456789abcdef',
-          HEROKU_APPLINK_TOKEN: 'token',
+          HEROKU_APPLINK_STAGING_API_URL: 'https://applink-api.heroku.com/addons/01234567-89ab-cdef-0123-456789abcdef',
+          HEROKU_APPLINK_STAGING_TOKEN: 'token',
         })
         .get('/apps/my-app/addons/6789abcd-ef01-2345-6789-abcdef012345/sso')
         .reply(200, sso_response)
@@ -208,6 +219,8 @@ describe('attempt a request using the applink API client', function () {
         .reply(200, app)
         .get('/apps/my-app/addons')
         .reply(200, [addon])
+        .get('/apps/my-app/addon-attachments')
+        .reply(200, [addonAttachment])
         .get('/apps/my-app/config-vars')
         .reply(200, {
           HEROKU_APPLINK_API_URL: 'https://applink-api.heroku.com/addons/01234567-89ab-cdef-0123-456789abcdef',
@@ -274,10 +287,14 @@ describe('attempt a request using the applink API client', function () {
         .reply(200, app)
         .get('/apps/my-app/addons')
         .reply(200, [addon, addon2])
+        .get('/apps/my-app/addon-attachments')
+        .reply(200, [addonAttachment, addonAttachment2])
         .get('/apps/my-app/config-vars')
         .reply(200, {
           HEROKU_APPLINK_API_URL: 'https://applink-api.heroku.com/addons/01234567-89ab-cdef-0123-456789abcdef',
           HEROKU_APPLINK_TOKEN: 'token',
+          HEROKU_APPLINK_COBALT_API_URL: 'https://applink-api.heroku.com/addons/6789abcd-ef01-2345-6789-abcdef012345',
+          HEROKU_APPLINK_COBALT_TOKEN: 'token',
         })
     })
 


### PR DESCRIPTION
<!--
When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`).

Examples:

`feat: add growl notification to spaces:wait`

`fix: handle special characters in app names`

`chore: refactor tests`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->

## Description

[WI](https://gus.lightning.force.com/a07EE00002GsjoQYAR) - `[applink addon] Many-to-Many - Some commands return 403 when executed on cross-app attached addon`
[WI](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002GwjHIYAZ/view) - [AppLink] Investigate and fix problem with AppLink config vars

Now that we support add-ons that are attached from other apps, we need to use the add-on attachment name when determining the AppLink config vars that we need to use.

Previously, we were getting an add-on's info from the Heroku API and using the `config_vars` field. That will work when the app has a single add-on, but not when it has more than one.

Getting the add-on attachments with `GET /apps/${app}/addon-attachments` allows us to construct the correct config var names, regardless of which app the add-on was provisioned to or how many add-ons the app has.

Slack thread: https://salesforce-internal.slack.com/archives/C06EA6CPVST/p1750865551648939

## Testing

A simple repro in the staging environment:

1. `heroku apps:create app1`
2. `heroku apps:create app2`
3. `heroku addons:create heroku-applink-staging -a app1`
4. `heroku addons:create heroku-applink-staging -a app2`
5. `heroku addons:attach <add-on name from step 4> -a app1`
6. `HEROKU_APPLINK_ADDON=heroku-applink-staging heroku applink:connections -a app1 --addon <add-on name from step 4>`

Without the fix, you get a 403 error:
```
» HEROKU_APPLINK_ADDON=heroku-applink-staging heroku applink:connections -a app1  --addon applink-staging-vertical-36559
    Error: HTTP Error 403 for GET https://applink.staging.herokudev.com/addons/81cab660-1762-497f-9d77-b8ce75c495d3/connections
    secure connection required
```

With the fix, you don't get an error:
```
» HEROKU_APPLINK_ADDON=heroku-applink-staging heroku applink:connections -a app1  --addon applink-staging-vertical-36559
There are no Heroku AppLink connections for app ⬢ app1.
```