### PR TITLE
fix: Correct reference to Heroku CLI command to list addons on an app

### DIFF
--- a/src/lib/base.ts
+++ b/src/lib/base.ts
@@ -67,7 +67,7 @@ export default abstract class extends Command {
         ux.error(
           heredoc`
             AppLink add-on ${color.addon(addon)} doesn't exist on ${color.app(app)}.
-            Use ${color.cmd(`heroku addons:list --app ${app}`)} to list the add-ons on the app.
+            Use ${color.cmd(`heroku addons --app ${app}`)} to list the add-ons on the app.
           `,
           {exit: 1}
         )

--- a/test/lib/base.test.ts
+++ b/test/lib/base.test.ts
@@ -272,7 +272,7 @@ describe('attempt a request using the applink API client', function () {
         const {message, oclif} = error as CLIError
         expect(stripAnsi(message)).to.equal(heredoc`
           AppLink add-on my-addon-2 doesn't exist on my-app.
-          Use heroku addons:list --app my-app to list the add-ons on the app.
+          Use heroku addons --app my-app to list the add-ons on the app.
         `)
         expect(oclif.exit).to.equal(1)
       }


### PR DESCRIPTION
## Description

When referencing a invalid add-on name, the CLI help response suggests running `heroku addons:list` to list the add-ons on the app and find one. `heroku addons:list` is not a valid command, and this functionality is provided by `heroku addons`.

This PR updates the reference to the command to update it to the correct `heroku addons`, and updates the corresponding test.

```
➜  ~ heroku applink:connections --addon HEROKU_APPLINK_ORANGE -a damp-mesa-89085
 ›   Error: AppLink add-on HEROKU_APPLINK_ORANGE doesn't exist on ⬢ damp-mesa-89085.
 ›   Use heroku addons:list --app damp-mesa-89085 to list the add-ons on the app.
 

➜  ~ heroku addons:list -a damp-mesa-89085
 ›   Warning: addons:list is not a heroku command.
```

## Testing

1. Run the command `heroku applink:connections --addon this-doesnt-exist -a APP_NAME` for one of your apps. The app must have a `heroku-applink` add-on provisioned, although its state doesn't matter.
2. The CLI will not be able to find the right add-on (we used a fake name above!). It will suggest listing your app's add-ons to identify the right add-on name. The CLI must now suggest using `heroku addons`, not `heroku addons:list`.

## Screenshots (if applicable)
N/A