### PR TITLE
fix: fix typo in datacloud:data-action-target:create

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ ARGUMENTS
 FLAGS
   -a, --app=<value>              (required) app to run command against
   -n, --api-name=<value>         [default: <LABEL>] API name for the data action target
-  -o, --connection-name=<value>  (required) Data Cloud connection namee to create the data action target
+  -o, --connection-name=<value>  (required) Data Cloud connection name to create the data action target
   -p, --target-api-path=<value>  (required) API path for the data action target excluding app URL, eg "/" or
                                  "/handleDataCloudDataChangeEvent"
   -r, --remote=<value>           git remote of app to use

--- a/src/commands/datacloud/data-action-target/create.ts
+++ b/src/commands/datacloud/data-action-target/create.ts
@@ -12,7 +12,7 @@ export default class Create extends Command {
     addon: flags.string({description: 'unique name or ID of an AppLink add-on'}),
     app: flags.app({required: true}),
     'api-name': flags.string({char: 'n', description: '[default: <LABEL>] API name for the data action target'}),
-    'connection-name': flags.string({char: 'o', required: true, description: 'Data Cloud connection namee to create the data action target'}),
+    'connection-name': flags.string({char: 'o', required: true, description: 'Data Cloud connection name to create the data action target'}),
     'target-api-path': flags.string({char: 'p', required: true, description: 'API path for the data action target excluding app URL, eg "/" or "/handleDataCloudDataChangeEvent"'}),
     type: flags.string({
       char: 't',


### PR DESCRIPTION
<!--
When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`).

Examples:

`feat: add growl notification to spaces:wait`

`fix: handle special characters in app names`

`chore: refactor tests`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->

## Description

Fixes a typo in a flag description for `datacloud:data-action-target:create`.

## Testing

**Notes**: N/A

1. CI passes
2. Typo has been fixed

