### PR TITLE
refactor: Continue Migrating Applink Commands PR 3 of 4

### DIFF
--- a/.c8rc.json
+++ b/.c8rc.json
@@ -6,6 +6,7 @@
     "test/**/*",
     "dist/**/*",
     "src/commands/**/*",
+    "src/lib/base.ts",
     "src/lib/jwtAuthCommand.ts",
     "src/index.ts"
   ],

--- a/.c8rc.json
+++ b/.c8rc.json
@@ -5,10 +5,8 @@
     "**/*.test.ts",
     "test/**/*",
     "dist/**/*",
-    "src/commands/**/*",
-    "src/lib/base.ts",
-    "src/lib/jwtAuthCommand.ts",
-    "src/index.ts"
+    "src/index.ts",
+    "src/lib/types.ts"
   ],
   "extension": [".ts"],
   "reporter": ["text", "text-summary", "html", "lcov"],

--- a/.mocharc.json
+++ b/.mocharc.json
@@ -3,6 +3,6 @@
   "watch-extensions": ["ts"],
   "recursive": true,
   "reporter": "spec",
-  "timeout": 5000,
+  "timeout": 360000,
   "node-option": ["import=tsx/esm"]
 }

--- a/package.json
+++ b/package.json
@@ -67,6 +67,22 @@
             "description": "list and view AppLink connections"
           }
         }
+      },
+      "salesforce": {
+        "description": "manage Heroku app connections to a Salesforce Org",
+        "subtopics": {
+          "authorizations": {
+            "description": "manage authorizations for connecting Salesforce orgs to Heroku apps",
+            "subtopics": {
+              "jwt": {
+                "description": "manage JWT-based authorizations for Salesforce connections"
+              }
+            }
+          },
+          "connect": {
+            "description": "manage connections between Salesforce orgs and Heroku apps"
+          }
+        }
       }
     }
   },

--- a/src/commands/salesforce/authorizations/add.ts
+++ b/src/commands/salesforce/authorizations/add.ts
@@ -1,0 +1,130 @@
+import {flags} from '@heroku-cli/command';
+import * as color from '@heroku/heroku-cli-util/color';
+import {anykey} from '@heroku/heroku-cli-util/hux';
+import {Args} from '@oclif/core';
+import {ux} from '@oclif/core/ux';
+import open from 'open';
+
+import * as AppLink from '../../../lib/applink/types.js';
+import AppLinkCommand from '../../../lib/base.js';
+import {humanize} from '../../../lib/helpers.js';
+
+export default class Add extends AppLinkCommand {
+  public static anykeyHandler: (message?: string) => Promise<string> = anykey;
+  static args = {
+    developer_name: Args.string({
+      description:
+        'unique developer name for the authorization. Must begin with a letter, end with a letter or a number,'
+        + " and between 3-30 characters. Only alphanumeric characters and non-consecutive underscores ('_') are allowed.",
+      required: true,
+    }),
+  };
+  static description
+    = "store a user's credentials for connecting a Salesforce org to a Heroku app";
+  static flags = {
+    addon: flags.string({
+      description: 'unique name or ID of an AppLink add-on',
+    }),
+    app: flags.app({required: true}),
+    browser: flags.string({
+      description:
+        'browser to open OAuth flow with (example: "firefox", "safari")',
+    }),
+    'login-url': flags.string({
+      char: 'l',
+      description: 'Salesforce login URL',
+    }),
+    remote: flags.remote(),
+    url: flags.boolean({
+      hidden: true,
+    }),
+  };
+  public static urlOpener: (
+    ..._args: Parameters<typeof open>
+  ) => ReturnType<typeof open> = open;
+
+  protected isPendingStatus(status: string): boolean {
+    return status === 'authorizing';
+  }
+
+  public async run(): Promise<void> {
+    const {args, flags} = await this.parse(Add);
+    const {addon, app, browser, 'login-url': loginUrl, url} = flags;
+    const {developer_name: developerName} = args;
+
+    await this.configureAppLinkClient(app, addon);
+    let authorization: AppLink.Authorization;
+    ({body: authorization}
+      = await this.applinkClient.post<AppLink.Authorization>(
+        `/addons/${this.addonId}/authorizations/salesforce`,
+        {
+          body: {
+            developer_name: developerName,
+            login_url: loginUrl,
+          },
+          headers: {authorization: `Bearer ${this._applinkToken}`},
+          retryAuth: false,
+        },
+      ));
+
+    const {id, redirect_uri: redirectUri} = authorization;
+
+    if (url) {
+      ux.stdout(JSON.stringify(redirectUri));
+      return;
+    }
+
+    process.stderr.write(`Opening browser to ${redirectUri}\n`);
+    let urlDisplayed = false;
+    const showBrowserError = () => {
+      if (!urlDisplayed)
+        ux.warn("We can't open the browser. Try again, or use a different browser.");
+      urlDisplayed = true;
+    };
+
+    try {
+      await Add.anykeyHandler(`Press any key to open up the browser to add credentials to ${color.app(app)} as ${color.yellow(developerName)}, or ${color.yellow('q')} to exit`);
+    } catch (error) {
+      const {message} = error as Error;
+      ux.error(message, {exit: 1});
+    }
+
+    const cp = await Add.urlOpener(redirectUri as string, {
+      wait: false,
+      ...(browser ? {app: {name: browser}} : {}),
+    });
+    cp.on('error', (err: Error) => {
+      ux.warn(err);
+      showBrowserError();
+    });
+    cp.on('close', (code: number) => {
+      if (code !== 0) showBrowserError();
+    });
+
+    ux.action.start(`Adding credentials to ${color.app(app)} as ${color.yellow(developerName)}`);
+    let {status} = authorization;
+    ux.action.status = humanize(status);
+
+    /* eslint-disable no-await-in-loop */
+    while (this.isPendingStatus(status)) {
+      await new Promise(resolve => {
+        setTimeout(resolve, 5000);
+      });
+
+      ({body: authorization}
+        = await this.applinkClient.get<AppLink.Authorization>(
+          `/addons/${this.addonId}/authorizations/${id}`,
+          {
+            headers: {authorization: `Bearer ${this._applinkToken}`},
+            retryAuth: false,
+          },
+        ));
+
+      ({status} = authorization);
+      ux.action.status = humanize(status);
+    }
+    /* eslint-enable no-await-in-loop */
+
+    ux.action.stop(humanize(status));
+  }
+}

--- a/src/commands/salesforce/authorizations/jwt/add.ts
+++ b/src/commands/salesforce/authorizations/jwt/add.ts
@@ -1,0 +1,21 @@
+import JWTAuthCommand from '../../../../lib/jwtAuthCommand.js';
+
+export default class JWT extends JWTAuthCommand {
+  static args = JWTAuthCommand.args;
+  static description
+    = "store a user's credentials for connecting a Salesforce org to a Heroku app using a JWT auth token";
+  static examples = JWTAuthCommand.generateExamples('salesforce:authorizations:jwt:add');
+  static flags = JWTAuthCommand.flags;
+
+  protected get commandName(): string {
+    return 'salesforce:authorizations:jwt:add';
+  }
+
+  protected get providerDisplayName(): string {
+    return 'Salesforce';
+  }
+
+  protected get providerName(): string {
+    return 'salesforce';
+  }
+}

--- a/src/commands/salesforce/authorizations/remove.ts
+++ b/src/commands/salesforce/authorizations/remove.ts
@@ -1,0 +1,53 @@
+import {flags} from '@heroku-cli/command';
+import * as color from '@heroku/heroku-cli-util/color';
+import {confirmCommand} from '@heroku/heroku-cli-util/hux';
+import {Args} from '@oclif/core';
+import {ux} from '@oclif/core/ux';
+
+import * as AppLink from '../../../lib/applink/types.js';
+import AppLinkCommand from '../../../lib/base.js';
+
+export default class Remove extends AppLinkCommand {
+  static args = {
+    developer_name: Args.string({
+      description: 'developer name of the Salesforce authorization',
+      required: true,
+    }),
+  };
+  static description = 'remove a Salesforce authorization from a Heroku app';
+  static flags = {
+    addon: flags.string({
+      description: 'unique name or ID of an AppLink add-on',
+    }),
+    app: flags.app({required: true}),
+    confirm: flags.string({
+      char: 'c',
+      description: 'set to developer name to bypass confirm prompt',
+    }),
+    remote: flags.remote(),
+  };
+
+  public async run(): Promise<void> {
+    const {args, flags} = await this.parse(Remove);
+    const {addon, app, confirm} = flags;
+    const {developer_name: developerName} = args;
+
+    await this.configureAppLinkClient(app, addon);
+
+    await confirmCommand({
+      comparison: developerName,
+      confirmation: confirm,
+      warningMessage: `This command removes the ${color.red(developerName)} credentials from app ${color.app(app)}.`,
+    });
+
+    ux.action.start(`Removing credentials ${color.yellow(developerName)} from ${color.app(app)}`);
+    await this.applinkClient.delete<AppLink.Authorization>(
+      `/addons/${this.addonId}/authorizations/${developerName}`,
+      {
+        headers: {authorization: `Bearer ${this._applinkToken}`},
+        retryAuth: false,
+      },
+    );
+    ux.action.stop();
+  }
+}

--- a/src/commands/salesforce/connect/index.ts
+++ b/src/commands/salesforce/connect/index.ts
@@ -1,0 +1,120 @@
+import {flags} from '@heroku-cli/command';
+import * as color from '@heroku/heroku-cli-util/color';
+import {anykey} from '@heroku/heroku-cli-util/hux';
+import {Args} from '@oclif/core';
+import {ux} from '@oclif/core/ux';
+import open from 'open';
+
+import * as AppLink from '../../../lib/applink/types.js';
+import AppLinkCommand from '../../../lib/base.js';
+import {humanize} from '../../../lib/helpers.js';
+
+export default class Connect extends AppLinkCommand {
+  public static anykeyHandler: (message?: string) => Promise<string> = anykey;
+  static args = {
+    connection_name: Args.string({
+      description:
+        'name for the Salesforce connection. Must begin with a letter, end with a letter or a number,'
+        + " and be between 3-30 characters. Only alphanumeric characters and non-consecutive underscores ('_') are allowed.",
+      required: true,
+    }),
+  };
+  static description = 'connect a Salesforce org to a Heroku app';
+  static flags = {
+    addon: flags.string({
+      description: 'unique name or ID of an AppLink add-on',
+    }),
+    app: flags.app({required: true}),
+    browser: flags.string({
+      description:
+        'browser to open OAuth flow with (example: "firefox", "safari")',
+    }),
+    'login-url': flags.string({char: 'l', description: 'login URL'}),
+    remote: flags.remote(),
+  };
+  public static urlOpener: (
+    ..._args: Parameters<typeof open>
+  ) => ReturnType<typeof open> = open;
+
+  protected isPendingStatus(status: string): boolean {
+    return (
+      status !== 'connected' && status !== 'failed' && status !== 'disconnected'
+    );
+  }
+
+  public async run(): Promise<void> {
+    const {args, flags} = await this.parse(Connect);
+    const {addon, app, browser, 'login-url': loginUrl} = flags;
+    const {connection_name: connectionName} = args;
+
+    await this.configureAppLinkClient(app, addon);
+    let connection: AppLink.SalesforceConnection;
+    ({body: connection}
+      = await this.applinkClient.post<AppLink.SalesforceConnection>(
+        `/addons/${this.addonId}/connections/salesforce`,
+        {
+          body: {
+            connection_name: connectionName,
+            login_url: loginUrl,
+          },
+          headers: {authorization: `Bearer ${this._applinkToken}`},
+          retryAuth: false,
+        },
+      ));
+
+    const {id, redirect_uri: redirectUri} = connection;
+
+    process.stderr.write(`Opening browser to ${redirectUri}\n`);
+    let urlDisplayed = false;
+    const showBrowserError = () => {
+      if (!urlDisplayed)
+        ux.warn("We can't open the browser. Try again, or use a different browser.");
+      urlDisplayed = true;
+    };
+
+    try {
+      await Connect.anykeyHandler(`Press any key to open up the browser to connect ${color.app(app)} to ${color.yellow(connectionName)}, or ${color.yellow('q')} to exit`);
+    } catch (error) {
+      const {message} = error as Error;
+      ux.error(message, {exit: 1});
+    }
+
+    const cp = await Connect.urlOpener(redirectUri as string, {
+      wait: false,
+      ...(browser ? {app: {name: browser}} : {}),
+    });
+    cp.on('error', (err: Error) => {
+      ux.warn(err);
+      showBrowserError();
+    });
+    cp.on('close', (code: number) => {
+      if (code !== 0) showBrowserError();
+    });
+
+    ux.action.start(`Connecting Salesforce org to ${color.app(app)} as ${color.yellow(connectionName)}`);
+    let {status} = connection;
+    ux.action.status = humanize(status);
+
+    /* eslint-disable no-await-in-loop */
+    while (this.isPendingStatus(status)) {
+      await new Promise(resolve => {
+        setTimeout(resolve, 5000);
+      });
+
+      ({body: connection}
+        = await this.applinkClient.get<AppLink.SalesforceConnection>(
+          `/addons/${this.addonId}/connections/${id}`,
+          {
+            headers: {authorization: `Bearer ${this._applinkToken}`},
+            retryAuth: false,
+          },
+        ));
+
+      ({status} = connection);
+      ux.action.status = humanize(status);
+    }
+    /* eslint-enable no-await-in-loop */
+
+    ux.action.stop(humanize(status));
+  }
+}

--- a/src/commands/salesforce/connect/jwt.ts
+++ b/src/commands/salesforce/connect/jwt.ts
@@ -1,0 +1,82 @@
+import {flags} from '@heroku-cli/command';
+import * as color from '@heroku/heroku-cli-util/color';
+import {Args} from '@oclif/core';
+import {ux} from '@oclif/core/ux';
+import {randomUUID} from 'node:crypto';
+import fs from 'node:fs';
+
+import * as AppLink from '../../../lib/applink/types.js';
+import AppLinkCommand from '../../../lib/base.js';
+import {humanize} from '../../../lib/helpers.js';
+
+export default class JWT extends AppLinkCommand {
+  static args = {
+    connection_name: Args.string({
+      description:
+        'name for the Salesforce connection. Must begin with a letter, end with a letter or a number,'
+        + " and be between 3-30 characters. Only alphanumeric characters and non-consecutive underscores ('_') are allowed.",
+      required: true,
+    }),
+  };
+  static description
+    = 'connect a Salesforce org to Heroku app using a JWT auth token';
+  static flags = {
+    addon: flags.string({
+      description: 'unique name or ID of an AppLink add-on',
+    }),
+    app: flags.app({required: true}),
+    'client-id': flags.string({
+      description: 'ID of consumer key',
+      required: true,
+    }),
+    'jwt-key-file': flags.file({
+      description: 'path to file containing private key to authorize with',
+      required: true,
+    }),
+    'login-url': flags.string({
+      char: 'l',
+      description: 'Salesforce login URL',
+    }),
+    remote: flags.remote(),
+    username: flags.string({
+      description: 'Salesforce username',
+      required: true,
+    }),
+  };
+
+  public async run(): Promise<void> {
+    const {args, flags} = await this.parse(JWT);
+    const {
+      addon,
+      app,
+      'client-id': clientId,
+      'jwt-key-file': jwtKeyFile,
+      'login-url': loginUrl,
+      username,
+    } = flags;
+    const {connection_name: connectionName} = args;
+    const keyFileContents = fs.readFileSync(jwtKeyFile).toString();
+
+    await this.configureAppLinkClient(app, addon);
+
+    ux.action.start(`Adding credentials for ${username} to ${color.app(app)} as ${color.yellow(connectionName)}`);
+
+    const {body: credential}
+      = await this.applinkClient.post<AppLink.CredsCredential>(
+        `/addons/${this.addonId}/connections/salesforce/jwt`,
+        {
+          body: {
+            alias: randomUUID(),
+            client_id: clientId,
+            connection_name: connectionName,
+            jwt_private_key: keyFileContents,
+            login_url: loginUrl,
+            username,
+          },
+          headers: {authorization: `Bearer ${this._applinkToken}`},
+        },
+      );
+
+    ux.action.stop(humanize(credential.status));
+  }
+}

--- a/src/commands/salesforce/disconnect.ts
+++ b/src/commands/salesforce/disconnect.ts
@@ -1,0 +1,72 @@
+import {flags} from '@heroku-cli/command';
+import * as color from '@heroku/heroku-cli-util/color';
+import {confirmCommand} from '@heroku/heroku-cli-util/hux';
+import {Args} from '@oclif/core';
+import {ux} from '@oclif/core/ux';
+import tsheredoc from 'tsheredoc';
+
+import * as AppLink from '../../lib/applink/types.js';
+import AppLinkCommand from '../../lib/base.js';
+import {humanize} from '../../lib/helpers.js';
+
+const heredoc = tsheredoc.default ?? tsheredoc;
+
+export default class Disconnect extends AppLinkCommand {
+  static args = {
+    connection_name: Args.string({
+      description:
+        'name of the Salesforce connection you would like to disconnect',
+      required: true,
+    }),
+  };
+  static description = 'disconnect a Salesforce org from a Heroku app';
+  static flags = {
+    addon: flags.string({
+      description: 'unique name or ID of an AppLink add-on',
+    }),
+    app: flags.app({required: true}),
+    confirm: flags.string({
+      char: 'c',
+      description: 'set to Salesforce connection name to bypass confirm prompt',
+    }),
+    remote: flags.remote(),
+  };
+
+  public async run(): Promise<void> {
+    const {args, flags} = await this.parse(Disconnect);
+    const {addon, app, confirm} = flags;
+    const {connection_name: connectionName} = args;
+
+    await this.configureAppLinkClient(app, addon);
+
+    await confirmCommand({
+      comparison: connectionName,
+      confirmation: confirm,
+    });
+
+    try {
+      await this.applinkClient.delete<AppLink.SalesforceConnection>(
+        `/addons/${this.addonId}/connections/${connectionName}`,
+        {
+          headers: {authorization: `Bearer ${this._applinkToken}`},
+          retryAuth: false,
+        },
+      );
+    } catch (error) {
+      const connErr = error as AppLink.ConnectionError;
+      if (connErr.body && connErr.body.id === 'record_not_found') {
+        ux.error(
+          heredoc`
+            Salesforce connection ${color.yellow(connectionName)} doesn't exist on app ${color.app(app)}.
+            Use ${color.command(`heroku applink:connections --app ${app}`)} to list the connections on the app`,
+          {exit: 1},
+        );
+      } else {
+        throw error;
+      }
+    }
+
+    ux.action.start(`Disconnecting Salesforce connection ${color.yellow(connectionName)} from ${color.app(app)}`);
+    ux.action.stop(humanize('Disconnected'));
+  }
+}

--- a/src/commands/salesforce/publications.ts
+++ b/src/commands/salesforce/publications.ts
@@ -1,0 +1,114 @@
+import {flags} from '@heroku-cli/command';
+import * as color from '@heroku/heroku-cli-util/color';
+import {styledHeader, table} from '@heroku/heroku-cli-util/hux';
+import {ux} from '@oclif/core/ux';
+
+import * as AppLink from '../../lib/applink/types.js';
+import AppLinkCommand from '../../lib/base.js';
+
+export default class Publications extends AppLinkCommand {
+  static description = 'list Salesforce orgs the app is published to';
+  static flags = {
+    addon: flags.string({
+      description: 'unique name or ID of an AppLink add-on',
+    }),
+    app: flags.app({required: true}),
+    connection_name: flags.string({
+      description: 'name of the Salesforce connection',
+    }),
+    remote: flags.remote(),
+  };
+
+  public async run(): Promise<void> {
+    const {flags} = await this.parse(Publications);
+    const {addon, app, connection_name: connectionName} = flags;
+    const connections: AppLink.SalesforceConnection[] = [];
+    const publications: AppLink.Publication[] = [];
+
+    await this.configureAppLinkClient(app, addon);
+
+    if (connectionName) {
+      const {body: connectionResponse}
+        = await this.applinkClient.get<AppLink.SalesforceConnection>(
+          `/addons/${this.addonId}/connections/${connectionName}`,
+          {
+            headers: {authorization: `Bearer ${this._applinkToken}`},
+            retryAuth: false,
+          },
+        );
+      connections.push(connectionResponse);
+    } else {
+      const {body: connectionResponse} = await this.applinkClient.get<
+        AppLink.SalesforceConnection[]
+      >(`/addons/${this.addonId}/connections`, {
+        headers: {authorization: `Bearer ${this._applinkToken}`},
+        retryAuth: false,
+      });
+      connections.push(...connectionResponse);
+    }
+
+    if (connections.length === 0) {
+      ux.error(
+        `There are no Heroku AppLink connections for ${color.app(app)}.`,
+        {exit: 1},
+      );
+    }
+
+    const activeSFConnections = connections.filter(connection =>
+      connection.org.type === 'SalesforceOrg'
+        && connection.status === 'connected');
+    if (activeSFConnections.length === 0) {
+      ux.error(
+        `There are no active Heroku AppLink connections for ${color.app(app)}.`,
+        {exit: 1},
+      );
+    }
+
+    for (const connection of activeSFConnections) {
+      // eslint-disable-next-line no-await-in-loop
+      const {body: pubs} = await this.applinkClient.get<
+        AppLink.Publication[]
+      >(
+        `/addons/${this.addonId}/connections/salesforce/${connection.org.connection_name}/apps/${this._appId}`,
+        {
+          headers: {authorization: `Bearer ${this._applinkToken}`},
+          retryAuth: false,
+        },
+      );
+      publications.push(...pubs);
+    }
+
+    if (publications.length === 0) {
+      ux.stdout(`You haven't published ${color.app(app)} to a Salesforce org yet.`);
+    } else {
+      styledHeader(`Salesforce publications for app ${color.app(app)}`);
+
+      table(publications, {
+        connectionName: {
+          get: row => row.connection_name,
+          header: 'Connection Name',
+        },
+        createdBy: {
+          get: row => row.created_by,
+          header: 'Created By',
+        },
+        createdDate: {
+          get: row => row.created_at,
+          header: 'Created Date',
+        },
+        lastModified: {
+          get: row => row.last_modified_at,
+          header: 'Last Modified',
+        },
+        lastModifiedBy: {
+          get: row => row.last_modified_by,
+          header: 'Last Modified By',
+        },
+        orgId: {
+          get: row => row.org_id,
+          header: 'Org ID',
+        },
+      });
+    }
+  }
+}

--- a/src/commands/salesforce/publish.ts
+++ b/src/commands/salesforce/publish.ts
@@ -1,0 +1,189 @@
+import {flags} from '@heroku-cli/command';
+import * as color from '@heroku/heroku-cli-util/color';
+import {Args} from '@oclif/core';
+import {ux} from '@oclif/core/ux';
+import AdmZip from 'adm-zip';
+import axios from 'axios';
+import fs from 'node:fs';
+import path from 'node:path';
+
+import * as AppLink from '../../lib/applink/types.js';
+import AppLinkCommand from '../../lib/base.js';
+
+export default class Publish extends AppLinkCommand {
+  static args = {
+    api_spec_file_dir: Args.file({
+      description: 'path to OpenAPI 3.x spec file (JSON or YAML format)',
+      required: true,
+    }),
+  };
+  static description
+    = "publish an app's API specification to an authenticated Salesforce org";
+  static flags = {
+    addon: flags.string({
+      description: 'unique name or ID of an AppLink add-on',
+    }),
+    app: flags.app({required: true}),
+    'authorization-connected-app-name': flags.string({
+      description: 'name of connected app to create from our template',
+    }),
+    'authorization-external-client-app-name': flags.string({
+      description: 'specifies the external client connected app name',
+    }),
+    'authorization-permission-set-name': flags.string({
+      description: 'name of permission set to create from our template',
+    }),
+    'client-name': flags.string({
+      char: 'c',
+      description: 'name given to the client stub',
+      required: true,
+    }),
+    'connection-name': flags.string({
+      description: 'authenticated Salesforce connection name',
+      required: true,
+    }),
+    'metadata-dir': flags.string({
+      description:
+        'directory containing connected app, permission set, or API spec',
+    }),
+    remote: flags.remote(),
+  };
+  protected createZipArchive = async (files: AppLink.FileEntry[]) => {
+    const zipArchive = new AdmZip();
+    for (const file of files) zipArchive.addFile(file.name, file.content);
+    return zipArchive.toBuffer();
+  };
+
+  public async run(): Promise<void> {
+    const {args, flags} = await this.parse(Publish);
+    const {
+      addon,
+      app,
+      'authorization-connected-app-name': authorizationConnectedAppName,
+      'authorization-external-client-app-name': authExternalClientAppName,
+      'authorization-permission-set-name': authorizationPermissionSetName,
+      'client-name': clientName,
+      'connection-name': connectionName,
+      'metadata-dir': metadataDir,
+    } = flags;
+    const {api_spec_file_dir: apiSpecFileDir} = args;
+
+    let hasConnectedAppMetadata = false;
+    let hasPermissionSetMetadata = false;
+
+    const files: AppLink.FileEntry[] = [];
+
+    if (authorizationConnectedAppName) {
+      ux.warn(`${color.command('--authorization-connected-app-name')} is a deprecated flag. Use ${color.command('--authorization-external-client-app-name')} instead.`);
+    }
+
+    if (!fs.existsSync(apiSpecFileDir)) {
+      ux.error(
+        `The API spec file path ${apiSpecFileDir} doesn't exist. Make sure it's the correct path or use a different one, and try again.`,
+        {exit: 1},
+      );
+    }
+
+    const fileExtension = path.extname(apiSpecFileDir).toLowerCase();
+
+    if (!['.json', '.yaml', '.yml'].includes(fileExtension)) {
+      ux.error(
+        'API spec file path must be in YAML (.yaml/.yml) or JSON (.json) format.',
+        {exit: 1},
+      );
+    }
+
+    const apiSpecContent = fs.readFileSync(apiSpecFileDir);
+    const fileName
+      = fileExtension === '.json' ? 'api-spec.json' : 'api-spec.yaml';
+    files.push({
+      content: apiSpecContent,
+      name: fileName,
+    });
+
+    if (metadataDir) {
+      const dirFiles = fs.readdirSync(path.resolve(metadataDir));
+      hasConnectedAppMetadata = dirFiles.includes('connectedapp-meta.xml');
+      hasPermissionSetMetadata = dirFiles.includes('permissionset-meta.xml');
+
+      if (hasConnectedAppMetadata && authorizationConnectedAppName) {
+        ux.error(
+          'You can only specify the connected app name with connectedapp-meta.xml in the metadata directory or with the --authorization-connected-app-name flag, not both.',
+          {exit: 1},
+        );
+      }
+
+      if (hasPermissionSetMetadata && authorizationPermissionSetName) {
+        ux.error(
+          'You can only specify the permission set name with permissionset-meta.xml in the metadata directory or with the --authorization-permission-set-name flag, not both.',
+          {exit: 1},
+        );
+      }
+
+      if (hasConnectedAppMetadata) {
+        const connectedAppContent = fs.readFileSync(path.join(metadataDir, 'connectedapp-meta.xml'));
+        files.push({
+          content: connectedAppContent,
+          name: 'connectedapp-meta.xml',
+        });
+      }
+
+      if (hasPermissionSetMetadata) {
+        const permissionSetContent = fs.readFileSync(path.join(metadataDir, 'permissionset-meta.xml'));
+        files.push({
+          content: permissionSetContent,
+          name: 'permissionset-meta.xml',
+        });
+      }
+    }
+
+    const compressedContent = await this.createZipArchive(files);
+    const appRequestContent = {
+      authorization_connected_app_name: authorizationConnectedAppName,
+      authorization_external_client_app_name: authExternalClientAppName,
+      authorization_permission_set_name: authorizationPermissionSetName,
+      client_name: clientName,
+    };
+    const formData = new FormData();
+    formData.append(
+      'metadata',
+      new Blob([new Uint8Array(compressedContent)], {
+        type: 'application/zip',
+      }),
+    );
+    formData.append(
+      'app_request',
+      new Blob([JSON.stringify(appRequestContent)], {
+        type: 'application/json',
+      }),
+    );
+
+    await this.configureAppLinkClient(app, addon);
+
+    const publishURL = `https://${this._applink.defaults.host}/addons/${this.addonId}/connections/salesforce/${connectionName}/apps`;
+    const headers = this._applink.defaults.headers || {};
+
+    ux.action.start(`Publishing ${color.app(app)} to ${color.yellow(connectionName)} as ${color.yellow(clientName)}`);
+
+    await axios
+      .post(publishURL, formData, {
+        headers: {
+          accept: 'application/json',
+          Authorization: `Bearer ${this._applinkToken}`,
+          'Content-Type': 'multipart/form-data',
+          'User-Agent': headers['user-agent'],
+          'x-addon-sso': headers['x-addon-sso'],
+          'x-app-uuid': headers['x-app-uuid'],
+        },
+      })
+      .catch(error => {
+        if (error.response.data && error.response.data.message) {
+          ux.error(error.response.data.message, {exit: 1});
+        } else {
+          throw error;
+        }
+      });
+
+    ux.action.stop();
+  }
+}

--- a/src/lib/applink/types.ts
+++ b/src/lib/applink/types.ts
@@ -80,7 +80,7 @@ export function isDataCloudConnection(connection: Connection): connection is Dat
   return !isSalesforceConnection(connection);
 }
 
-export function adjustOrgType(type: string | undefined): string | undefined {
+export function adjustOrgType(type?: string): string | undefined {
   return type === 'DatacloudOrg' ? 'DataCloudOrg' : type;
 }
 

--- a/test/commands/salesforce/authorizations/add.test.ts
+++ b/test/commands/salesforce/authorizations/add.test.ts
@@ -1,2 +1,171 @@
-// This test will be migrated in a subsequent PR.
-export {};
+import {runCommand} from '@heroku-cli/test-utils';
+import {expect} from 'chai';
+import nock from 'nock';
+import {ChildProcess} from 'node:child_process';
+import sinon, {SinonSandbox, SinonStub} from 'sinon';
+
+import Cmd from '../../../../src/commands/salesforce/authorizations/add.js';
+import {
+  addon,
+  addonAttachment,
+  app,
+  authorization_authenticating,
+  authorization_connected,
+  authorization_connection_failed,
+  authorization_disconnected,
+  sso_response,
+} from '../../../helpers/fixtures.js';
+import stripAnsi from '../../../helpers/strip-ansi.js';
+
+describe('salesforce:authorizations:add', function () {
+  let api: nock.Scope;
+  let applinkApi: nock.Scope;
+  const {env} = process;
+  let sandbox: SinonSandbox;
+  let urlOpener: SinonStub;
+
+  beforeEach(function () {
+    process.env = {};
+    api = nock('https://api.heroku.com')
+      .get('/apps/my-app')
+      .reply(200, app)
+      .get('/apps/my-app/addons')
+      .reply(200, [addon])
+      .get('/apps/my-app/addon-attachments')
+      .reply(200, [addonAttachment])
+      .get('/apps/my-app/config-vars')
+      .reply(200, {
+        HEROKU_APPLINK_API_URL:
+          'https://applink-api.heroku.com/addons/01234567-89ab-cdef-0123-456789abcdef',
+        HEROKU_APPLINK_TOKEN: 'token',
+      })
+      .get('/apps/my-app/addons/01234567-89ab-cdef-0123-456789abcdef/sso')
+      .reply(200, sso_response);
+    applinkApi = nock('https://applink-api.heroku.com');
+    sandbox = sinon.createSandbox();
+  });
+
+  afterEach(function () {
+    process.env = env;
+    api.done();
+    applinkApi.done();
+    nock.cleanAll();
+    sandbox.restore();
+  });
+
+  context('when the user accepts the prompt to open the browser', function () {
+    beforeEach(function () {
+      urlOpener = sandbox
+        .stub(Cmd, 'urlOpener')
+        .onFirstCall()
+        .resolves({
+          on(_: string, _cb: (_err: Error) => void) {},
+        } as unknown as ChildProcess);
+      sandbox.stub(Cmd, 'anykeyHandler').resolves('');
+      applinkApi
+        .post('/addons/01234567-89ab-cdef-0123-456789abcdef/authorizations/salesforce')
+        .reply(202, authorization_authenticating);
+    });
+
+    context('when the connection succeeds', function () {
+      beforeEach(function () {
+        applinkApi
+          .get('/addons/01234567-89ab-cdef-0123-456789abcdef/authorizations/5551fe92-c2fb-4ef7-be43-9d927d9a5c53')
+          .reply(200, authorization_connected);
+      });
+
+      it('shows the URL that will be opened for the OAuth flow', async function () {
+        const {stderr} = await runCommand(Cmd, ['my-auth-1', '--app=my-app']);
+
+        expect(stderr).to.contain(`Opening browser to ${authorization_authenticating.redirect_uri}`);
+      });
+
+      it('attempts to open the browser to the redirect URI', async function () {
+        await runCommand(Cmd, ['my-auth-1', '--app=my-app']);
+
+        expect(urlOpener.calledWith(authorization_authenticating.redirect_uri, {
+          wait: false,
+        })).to.equal(true);
+      });
+
+      it('shows the expected output after connecting', async function () {
+        const {stderr} = await runCommand(Cmd, ['my-auth-1', '--app=my-app']);
+
+        expect(stripAnsi(stderr)).to.contain('Adding credentials to my-app as my-auth-1');
+        expect(stripAnsi(stderr)).to.contain('Authorized');
+      });
+    });
+
+    context('when the connection fails', function () {
+      it('completes polling when authorization status is disconnected', async function () {
+        applinkApi
+          .get('/addons/01234567-89ab-cdef-0123-456789abcdef/authorizations/5551fe92-c2fb-4ef7-be43-9d927d9a5c53')
+          .reply(200, authorization_connection_failed);
+
+        const {error} = await runCommand(Cmd, ['my-auth-1', '--app=my-app']);
+
+        expect(error).to.not.exist;
+      });
+
+      it('completes polling when authorization is disconnected without error', async function () {
+        applinkApi
+          .get('/addons/01234567-89ab-cdef-0123-456789abcdef/authorizations/5551fe92-c2fb-4ef7-be43-9d927d9a5c53')
+          .reply(200, authorization_disconnected);
+
+        const {error} = await runCommand(Cmd, ['my-auth-1', '--app=my-app']);
+
+        expect(error).to.not.exist;
+      });
+    });
+  });
+
+  context('when the user rejects the prompt to open the browser', function () {
+    beforeEach(function () {
+      urlOpener = sandbox.stub(Cmd, 'urlOpener');
+      sandbox.stub(Cmd, 'anykeyHandler').rejects(new Error('quit'));
+      applinkApi
+        .post('/addons/01234567-89ab-cdef-0123-456789abcdef/authorizations/salesforce')
+        .reply(202, authorization_authenticating);
+    });
+
+    it("doesn't attempt to open the browser to the redirect URI", async function () {
+      await runCommand(Cmd, ['my-auth-1', '--app=my-app']);
+
+      expect(urlOpener.notCalled).to.equal(true);
+    });
+  });
+
+  context('when the --url flag is provided', function () {
+    let anykeyStub: SinonStub;
+
+    beforeEach(function () {
+      urlOpener = sandbox.stub(Cmd, 'urlOpener');
+      anykeyStub = sandbox.stub(Cmd, 'anykeyHandler');
+      applinkApi
+        .post('/addons/01234567-89ab-cdef-0123-456789abcdef/authorizations/salesforce')
+        .reply(202, authorization_authenticating);
+    });
+
+    it('outputs the redirect URI', async function () {
+      const {stdout} = await runCommand(Cmd, [
+        'my-auth-1',
+        '--app=my-app',
+        '--url',
+      ]);
+
+      expect(stdout).to.contain(authorization_authenticating.redirect_uri!);
+    });
+
+    it("doesn't prompt the user to open the browser", async function () {
+      await runCommand(Cmd, ['my-auth-1', '--app=my-app', '--url']);
+
+      expect(anykeyStub.notCalled).to.equal(true);
+    });
+
+    it("doesn't attempt to open the browser", async function () {
+      await runCommand(Cmd, ['my-auth-1', '--app=my-app', '--url']);
+
+      expect(urlOpener.notCalled).to.equal(true);
+    });
+  });
+});

--- a/test/commands/salesforce/authorizations/add/jwt.test.ts
+++ b/test/commands/salesforce/authorizations/add/jwt.test.ts
@@ -1,2 +1,17 @@
-// This test will be migrated in a subsequent PR.
-export {};
+import Cmd from '../../../../../src/commands/salesforce/authorizations/jwt/add.js';
+import {
+  authorization_jwt_authorized,
+  authorization_jwt_authorizing,
+  authorization_jwt_failed,
+} from '../../../../helpers/fixtures.js';
+import {createJWTAuthCommandTests} from '../../../../helpers/jwtAuthCommandTests.js';
+
+createJWTAuthCommandTests({
+  commandClass: Cmd,
+  fixtures: {
+    authorized: authorization_jwt_authorized,
+    authorizing: authorization_jwt_authorizing,
+    failed: authorization_jwt_failed,
+  },
+  providerName: 'salesforce',
+});

--- a/test/commands/salesforce/authorizations/remove.test.ts
+++ b/test/commands/salesforce/authorizations/remove.test.ts
@@ -1,2 +1,58 @@
-// This test will be migrated in a subsequent PR.
-export {};
+import {runCommand} from '@heroku-cli/test-utils';
+import {expect} from 'chai';
+import nock from 'nock';
+
+import Cmd from '../../../../src/commands/salesforce/authorizations/remove.js';
+import {
+  addon,
+  addonAttachment,
+  app,
+  sso_response,
+} from '../../../helpers/fixtures.js';
+describe('salesforce:authorizations:remove', function () {
+  let api: nock.Scope;
+  let applinkApi: nock.Scope;
+  const {env} = process;
+
+  beforeEach(function () {
+    process.env = {};
+    api = nock('https://api.heroku.com')
+      .get('/apps/my-app')
+      .reply(200, app)
+      .get('/apps/my-app/addons')
+      .reply(200, [addon])
+      .get('/apps/my-app/addon-attachments')
+      .reply(200, [addonAttachment])
+      .get('/apps/my-app/config-vars')
+      .reply(200, {
+        HEROKU_APPLINK_API_URL:
+          'https://applink-api.heroku.com/addons/01234567-89ab-cdef-0123-456789abcdef',
+        HEROKU_APPLINK_TOKEN: 'token',
+      })
+      .get('/apps/my-app/addons/01234567-89ab-cdef-0123-456789abcdef/sso')
+      .reply(200, sso_response);
+    applinkApi = nock('https://applink-api.heroku.com');
+  });
+
+  afterEach(function () {
+    process.env = env;
+    api.done();
+    applinkApi.done();
+    nock.cleanAll();
+  });
+
+  it('successfully removes a Salesforce authorization from a Heroku app', async function () {
+    applinkApi
+      .delete('/addons/01234567-89ab-cdef-0123-456789abcdef/authorizations/my-auth-1')
+      .reply(200, {});
+
+    const {error} = await runCommand(Cmd, [
+      'my-auth-1',
+      '--app=my-app',
+      '--addon=heroku-applink-vertical-01234',
+      '--confirm=my-auth-1',
+    ]);
+
+    expect(error).to.not.exist;
+  });
+});

--- a/test/commands/salesforce/connect/index.test.ts
+++ b/test/commands/salesforce/connect/index.test.ts
@@ -1,2 +1,158 @@
-// This test will be migrated in a subsequent PR.
-export {};
+import {runCommand} from '@heroku-cli/test-utils';
+import {expect} from 'chai';
+import nock from 'nock';
+import {ChildProcess} from 'node:child_process';
+import sinon, {SinonSandbox, SinonStub} from 'sinon';
+
+import Cmd from '../../../../src/commands/salesforce/connect/index.js';
+import {
+  addon,
+  addonAttachment,
+  app,
+  connection2_connected,
+  connection2_connecting,
+  connection2_disconnected,
+  connection2_failed,
+  sso_response,
+} from '../../../helpers/fixtures.js';
+import stripAnsi from '../../../helpers/strip-ansi.js';
+
+describe('salesforce:connect', function () {
+  let api: nock.Scope;
+  const {env} = process;
+  let sandbox: SinonSandbox;
+  let urlOpener: SinonStub;
+
+  context('when config var is set to HEROKU_APPLINK_API_URL', function () {
+    let applinkApi: nock.Scope;
+
+    beforeEach(function () {
+      process.env = {};
+      api = nock('https://api.heroku.com')
+        .get('/apps/my-app')
+        .reply(200, app)
+        .get('/apps/my-app/addons')
+        .reply(200, [addon])
+        .get('/apps/my-app/addon-attachments')
+        .reply(200, [addonAttachment])
+        .get('/apps/my-app/config-vars')
+        .reply(200, {
+          HEROKU_APPLINK_API_URL:
+            'https://applink-api.heroku.com/addons/01234567-89ab-cdef-0123-456789abcdef',
+          HEROKU_APPLINK_TOKEN: 'token',
+        })
+        .get('/apps/my-app/addons/01234567-89ab-cdef-0123-456789abcdef/sso')
+        .reply(200, sso_response);
+      applinkApi = nock('https://applink-api.heroku.com');
+      sandbox = sinon.createSandbox();
+    });
+
+    afterEach(function () {
+      process.env = env;
+      api.done();
+      applinkApi.done();
+      nock.cleanAll();
+      sandbox.restore();
+    });
+
+    context(
+      'when the user accepts the prompt to open the browser',
+      function () {
+        beforeEach(function () {
+          urlOpener = sandbox
+            .stub(Cmd, 'urlOpener')
+            .onFirstCall()
+            .resolves({
+              on(_: string, _cb: (_err: Error) => void) {},
+            } as unknown as ChildProcess);
+          sandbox.stub(Cmd, 'anykeyHandler').resolves('');
+          applinkApi
+            .post('/addons/01234567-89ab-cdef-0123-456789abcdef/connections/salesforce')
+            .reply(202, connection2_connecting);
+        });
+
+        context('when the connection succeeds', function () {
+          beforeEach(function () {
+            applinkApi
+              .get('/addons/01234567-89ab-cdef-0123-456789abcdef/connections/5551fe92-c2fb-4ef7-be43-9d927d9a5c53')
+              .reply(200, connection2_connected);
+          });
+
+          it('shows the URL that will be opened for the OAuth flow', async function () {
+            const {stderr} = await runCommand(Cmd, [
+              'my-org-2',
+              '--app=my-app',
+            ]);
+
+            expect(stderr).to.contain(`Opening browser to ${connection2_connecting.redirect_uri}`);
+          });
+
+          it('attempts to open the browser to the redirect URI', async function () {
+            await runCommand(Cmd, ['my-org-2', '--app=my-app']);
+
+            expect(urlOpener.calledWith(connection2_connecting.redirect_uri, {
+              wait: false,
+            })).to.equal(true);
+          });
+
+          it('shows the expected output after connecting', async function () {
+            const {stderr} = await runCommand(Cmd, [
+              'my-org-2',
+              '--app=my-app',
+            ]);
+
+            expect(stripAnsi(stderr)).to.contain('Connecting Salesforce org to my-app as my-org-2');
+            expect(stripAnsi(stderr)).to.contain('Connected');
+          });
+        });
+
+        context('when the connection fails', function () {
+          it('completes polling when connection fails', async function () {
+            applinkApi
+              .get('/addons/01234567-89ab-cdef-0123-456789abcdef/connections/5551fe92-c2fb-4ef7-be43-9d927d9a5c53')
+              .reply(200, connection2_failed);
+
+            const {error} = await runCommand(Cmd, [
+              'my-org-2',
+              '--app=my-app',
+            ]);
+
+            expect(error).to.not.exist;
+          });
+
+          it('completes polling when connection is disconnected', async function () {
+            applinkApi
+              .get('/addons/01234567-89ab-cdef-0123-456789abcdef/connections/5551fe92-c2fb-4ef7-be43-9d927d9a5c53')
+              .reply(200, connection2_disconnected);
+
+            const {error} = await runCommand(Cmd, [
+              'my-org-2',
+              '--app=my-app',
+            ]);
+
+            expect(error).to.not.exist;
+          });
+        });
+      },
+    );
+
+    context(
+      'when the user rejects the prompt to open the browser',
+      function () {
+        beforeEach(function () {
+          urlOpener = sandbox.stub(Cmd, 'urlOpener');
+          sandbox.stub(Cmd, 'anykeyHandler').rejects(new Error('quit'));
+          applinkApi
+            .post('/addons/01234567-89ab-cdef-0123-456789abcdef/connections/salesforce')
+            .reply(202, connection2_connecting);
+        });
+
+        it("doesn't attempt to open the browser to the redirect URI", async function () {
+          await runCommand(Cmd, ['my-org-2', '--app=my-app']);
+
+          expect(urlOpener.notCalled).to.equal(true);
+        });
+      },
+    );
+  });
+});

--- a/test/commands/salesforce/connect/jwt.test.ts
+++ b/test/commands/salesforce/connect/jwt.test.ts
@@ -1,2 +1,86 @@
-// This test will be migrated in a subsequent PR.
-export {};
+import {runCommand} from '@heroku-cli/test-utils';
+import {expect} from 'chai';
+import nock from 'nock';
+import {dirname} from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+import Cmd from '../../../../src/commands/salesforce/connect/jwt.js';
+import {
+  addon,
+  addonAttachment,
+  app,
+  credential_id_connected,
+  credential_id_failed,
+  sso_response,
+} from '../../../helpers/fixtures.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+describe('salesforce:connect:jwt', function () {
+  let applinkApi: nock.Scope;
+  let api: nock.Scope;
+
+  const filePath = `${__dirname}/../../../helpers/jwt.key`;
+
+  beforeEach(function () {
+    api = nock('https://api.heroku.com')
+      .get('/apps/my-app')
+      .reply(200, app)
+      .get('/apps/my-app/addons')
+      .reply(200, [addon])
+      .get('/apps/my-app/addon-attachments')
+      .reply(200, [addonAttachment])
+      .get('/apps/my-app/config-vars')
+      .reply(200, {
+        HEROKU_APPLINK_API_URL:
+          'https://applink-api.heroku.com/addons/01234567-89ab-cdef-0123-456789abcdef',
+        HEROKU_APPLINK_TOKEN: 'token',
+      })
+      .get('/apps/my-app/addons/01234567-89ab-cdef-0123-456789abcdef/sso')
+      .reply(200, sso_response);
+    applinkApi = nock('https://applink-api.heroku.com');
+  });
+
+  afterEach(function () {
+    api.done();
+    applinkApi.done();
+    nock.cleanAll();
+  });
+
+  it('when the connection succeeds, it shows the expected output', async function () {
+    applinkApi
+      .post('/addons/01234567-89ab-cdef-0123-456789abcdef/connections/salesforce/jwt')
+      .reply(202, credential_id_connected);
+
+    const {error} = await runCommand(Cmd, [
+      'my-connection-1',
+      '--app=my-app',
+      '--client-id=test-id',
+      `--jwt-key-file=${filePath}`,
+      '--username=test-username',
+      '-l',
+      'https://test.salesforce.com',
+    ]);
+
+    expect(error).to.not.exist;
+  });
+
+  it('when the connection status is not "Connected", it shows the correct connection status in the output', async function () {
+    applinkApi
+      .post('/addons/01234567-89ab-cdef-0123-456789abcdef/connections/salesforce/jwt')
+      .reply(202, credential_id_failed);
+
+    const {error} = await runCommand(Cmd, [
+      'my-connection-1',
+      '--app=my-app',
+      '--client-id=test-id',
+      `--jwt-key-file=${filePath}`,
+      '--username=test-username',
+      '-l',
+      'https://test.salesforce.com',
+    ]);
+
+    expect(error).to.not.exist;
+  });
+});

--- a/test/commands/salesforce/disconnect.test.ts
+++ b/test/commands/salesforce/disconnect.test.ts
@@ -1,2 +1,164 @@
-// This test will be migrated in a subsequent PR.
-export {};
+import {runCommand} from '@heroku-cli/test-utils';
+import {expect} from 'chai';
+import nock from 'nock';
+
+import Cmd from '../../../src/commands/salesforce/disconnect.js';
+import {
+  addon,
+  addon2,
+  addonAttachment,
+  addonAttachment2,
+  app,
+  connection5_disconnecting,
+  ConnectionError_record_not_found,
+  sso_response,
+} from '../../helpers/fixtures.js';
+import stripAnsi from '../../helpers/strip-ansi.js';
+
+describe('salesforce:disconnect', function () {
+  let api: nock.Scope;
+  let applinkApi: nock.Scope;
+  const {env} = process;
+
+  context('when config var is set to HEROKU_APPLINK_API_URL', function () {
+    beforeEach(function () {
+      process.env = {};
+      api = nock('https://api.heroku.com')
+        .get('/apps/my-app')
+        .reply(200, app)
+        .get('/apps/my-app/addons')
+        .reply(200, [addon])
+        .get('/apps/my-app/addon-attachments')
+        .reply(200, [addonAttachment])
+        .get('/apps/my-app/config-vars')
+        .reply(200, {
+          HEROKU_APPLINK_API_URL:
+            'https://applink-api.heroku.com/addons/01234567-89ab-cdef-0123-456789abcdef',
+          HEROKU_APPLINK_TOKEN: 'token',
+        })
+        .get('/apps/my-app/addons/01234567-89ab-cdef-0123-456789abcdef/sso')
+        .reply(200, sso_response);
+      applinkApi = nock('https://applink-api.heroku.com');
+    });
+
+    afterEach(function () {
+      process.env = env;
+      api.done();
+      applinkApi.done();
+      nock.cleanAll();
+    });
+
+    it('waits for DELETE /connections/orgName status to return "disconnecting" before ending the action successfully', async function () {
+      applinkApi
+        .delete('/addons/01234567-89ab-cdef-0123-456789abcdef/connections/myorg')
+        .reply(202, connection5_disconnecting);
+
+      const {stderr} = await runCommand(Cmd, [
+        'myorg',
+        '--app=my-app',
+        '--confirm=myorg',
+      ]);
+
+      expect(stderr).to.contain('Disconnected');
+    });
+
+    it('connection not found', async function () {
+      applinkApi
+        .delete('/addons/01234567-89ab-cdef-0123-456789abcdef/connections/myorg')
+        .reply(404, ConnectionError_record_not_found.body);
+
+      const {error} = await runCommand(Cmd, [
+        'myorg',
+        '--app=my-app',
+        '--confirm=myorg',
+      ]);
+
+      expect(error).to.exist;
+      expect(stripAnsi(error!.message)).to.contain("Salesforce connection myorg doesn't exist on app my-app.");
+    });
+
+    it('errors when the wrong org name is passed to the confirm flag', async function () {
+      applinkApi
+        .delete('/addons/01234567-89ab-cdef-0123-456789abcdef/connections/myorg')
+        .optionally()
+        .reply(202, connection5_disconnecting);
+
+      const {error} = await runCommand(Cmd, [
+        'myorg',
+        '--app=my-app',
+        '--confirm=myorg2',
+      ]);
+
+      expect(error).to.exist;
+    });
+  });
+
+  context('when app has no AppLink add-on', function () {
+    beforeEach(function () {
+      process.env = {};
+      nock('https://api.heroku.com')
+        .get('/apps/my-app')
+        .reply(200, app)
+        .get('/apps/my-app/addons')
+        .reply(200, [])
+        .get('/apps/my-app/addon-attachments')
+        .reply(200, [])
+        .get('/apps/my-app/config-vars')
+        .reply(200, {});
+    });
+
+    afterEach(function () {
+      process.env = env;
+      nock.cleanAll();
+    });
+
+    it('shows an error that AppLink is not installed', async function () {
+      const {error} = await runCommand(Cmd, [
+        'myorg',
+        '--app=my-app',
+        '--confirm=myorg',
+      ]);
+
+      expect(error).to.exist;
+      expect(stripAnsi(error!.message)).to.contain("AppLink add-on isn't present on my-app");
+    });
+  });
+
+  context(
+    'when app has multiple AppLink add-ons without --addon flag',
+    function () {
+      beforeEach(function () {
+        process.env = {};
+        nock('https://api.heroku.com')
+          .get('/apps/my-app')
+          .reply(200, app)
+          .get('/apps/my-app/addons')
+          .reply(200, [addon, {...addon2, app}])
+          .get('/apps/my-app/addon-attachments')
+          .reply(200, [addonAttachment, addonAttachment2])
+          .get('/apps/my-app/config-vars')
+          .reply(200, {
+            HEROKU_APPLINK_API_URL:
+              'https://applink-api.heroku.com/addons/01234567',
+            HEROKU_APPLINK_TOKEN: 'token',
+          });
+      });
+
+      afterEach(function () {
+        process.env = env;
+        nock.cleanAll();
+      });
+
+      it('shows an error to specify --addon flag', async function () {
+        const {error} = await runCommand(Cmd, [
+          'myorg',
+          '--app=my-app',
+          '--confirm=myorg',
+        ]);
+
+        expect(error).to.exist;
+        expect(stripAnsi(error!.message)).to.contain('multiple AppLink add-ons');
+      });
+    },
+  );
+});

--- a/test/commands/salesforce/publications.test.ts
+++ b/test/commands/salesforce/publications.test.ts
@@ -1,2 +1,126 @@
-// This test will be migrated in a subsequent PR.
-export {};
+import {runCommand} from '@heroku-cli/test-utils';
+import {expect} from 'chai';
+import nock from 'nock';
+
+import Cmd from '../../../src/commands/salesforce/publications.js';
+import {
+  addon,
+  addonAttachment,
+  app,
+  connection1,
+  connection2_connected,
+  connection2_connecting,
+  connection2_failed,
+  publication1,
+  publication2,
+  sso_response,
+} from '../../helpers/fixtures.js';
+import stripAnsi from '../../helpers/strip-ansi.js';
+import removeAllWhitespace from '../../helpers/utils/remove-whitespaces.js';
+
+describe('salesforce:publications', function () {
+  let api: nock.Scope;
+  let applinkApi: nock.Scope;
+  const {env} = process;
+
+  beforeEach(function () {
+    process.env = {};
+    api = nock('https://api.heroku.com');
+    applinkApi = nock('https://applink-api.heroku.com');
+
+    api
+      .get('/apps/my-app')
+      .reply(200, app)
+      .get('/apps/my-app/addons')
+      .reply(200, [addon])
+      .get('/apps/my-app/addon-attachments')
+      .reply(200, [addonAttachment])
+      .get('/apps/my-app/config-vars')
+      .reply(200, {
+        HEROKU_APPLINK_API_URL:
+          'https://applink-api.heroku.com/addons/01234567-89ab-cdef-0123-456789abcdef',
+        HEROKU_APPLINK_TOKEN: 'token',
+      })
+      .get('/apps/my-app/addons/01234567-89ab-cdef-0123-456789abcdef/sso')
+      .reply(200, sso_response);
+  });
+
+  afterEach(function () {
+    process.env = env;
+    api.done();
+    applinkApi.done();
+    nock.cleanAll();
+  });
+
+  it('when there are no Heroku AppLink connections on the app it displays an error', async function () {
+    applinkApi
+      .get('/addons/01234567-89ab-cdef-0123-456789abcdef/connections')
+      .reply(200, []);
+
+    const {error} = await runCommand(Cmd, ['--app=my-app']);
+
+    expect(error).to.exist;
+    expect(stripAnsi(error!.message)).to.contain('There are no Heroku AppLink connections for my-app.');
+  });
+
+  it('when there are no active Heroku AppLink connections on the app it displays an error', async function () {
+    applinkApi
+      .get('/addons/01234567-89ab-cdef-0123-456789abcdef/connections')
+      .reply(200, [connection2_connecting, connection2_failed]);
+
+    const {error} = await runCommand(Cmd, ['--app=my-app']);
+
+    expect(error).to.exist;
+    expect(stripAnsi(error!.message)).to.contain('There are no active Heroku AppLink connections for my-app.');
+  });
+
+  it('when the app has not been published to a Salesforce org it shows a message', async function () {
+    applinkApi
+      .get('/addons/01234567-89ab-cdef-0123-456789abcdef/connections')
+      .reply(200, [connection1, connection2_connected])
+      .get('/addons/01234567-89ab-cdef-0123-456789abcdef/connections/salesforce/my-org-1/apps/89abcdef-0123-4567-89ab-cdef01234567')
+      .reply(200, [])
+      .get('/addons/01234567-89ab-cdef-0123-456789abcdef/connections/salesforce/my-org-2/apps/89abcdef-0123-4567-89ab-cdef01234567')
+      .reply(200, []);
+
+    const {stdout} = await runCommand(Cmd, ['--app=my-app']);
+
+    expect(stripAnsi(stdout)).to.contain("You haven't published my-app to a Salesforce org yet.");
+  });
+
+  it('when the app has been published to active Salesforce connections it prints a table with publication details', async function () {
+    applinkApi
+      .get('/addons/01234567-89ab-cdef-0123-456789abcdef/connections')
+      .reply(200, [connection1, connection2_connected])
+      .get('/addons/01234567-89ab-cdef-0123-456789abcdef/connections/salesforce/my-org-1/apps/89abcdef-0123-4567-89ab-cdef01234567')
+      .reply(200, [publication1])
+      .get('/addons/01234567-89ab-cdef-0123-456789abcdef/connections/salesforce/my-org-2/apps/89abcdef-0123-4567-89ab-cdef01234567')
+      .reply(200, [publication2]);
+
+    const {stdout} = await runCommand(Cmd, ['--app=my-app']);
+
+    const actual = removeAllWhitespace(stdout);
+    expect(actual).to.include(removeAllWhitespace('Salesforce publications for app'));
+    expect(actual).to.include(removeAllWhitespace('connection1'));
+    expect(actual).to.include(removeAllWhitespace('connection2'));
+    expect(actual).to.include(removeAllWhitespace('00DSG000007a3BcA84'));
+    expect(actual).to.include(removeAllWhitespace('user@example.com'));
+  });
+
+  it('when the connection_name flag is specified and app has been published to the specified Salesforce connection it prints a table', async function () {
+    applinkApi
+      .get('/addons/01234567-89ab-cdef-0123-456789abcdef/connections/connection1')
+      .reply(200, connection1)
+      .get('/addons/01234567-89ab-cdef-0123-456789abcdef/connections/salesforce/my-org-1/apps/89abcdef-0123-4567-89ab-cdef01234567')
+      .reply(200, [publication1]);
+
+    const {stdout} = await runCommand(Cmd, [
+      '--app=my-app',
+      '--connection_name=connection1',
+    ]);
+
+    const actual = removeAllWhitespace(stdout);
+    expect(actual).to.include(removeAllWhitespace('connection1'));
+    expect(actual).to.include(removeAllWhitespace('00DSG000007a3BcA84'));
+  });
+});

--- a/test/commands/salesforce/publish.test.ts
+++ b/test/commands/salesforce/publish.test.ts
@@ -1,2 +1,217 @@
-// This test will be migrated in a subsequent PR.
-export {};
+import {runCommand} from '@heroku-cli/test-utils';
+import {expect} from 'chai';
+import nock from 'nock';
+import fs from 'node:fs';
+import {dirname} from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+import Cmd from '../../../src/commands/salesforce/publish.js';
+import {
+  addon,
+  addonAttachment,
+  app,
+  sso_response,
+} from '../../helpers/fixtures.js';
+import stripAnsi from '../../helpers/strip-ansi.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+describe('salesforce:publish', function () {
+  let api: nock.Scope;
+  let applinkApi: nock.Scope;
+  const {env} = process;
+
+  context('when config var is set to HEROKU_APPLINK_API_URL', function () {
+    beforeEach(function () {
+      process.env = {};
+      api = nock('https://api.heroku.com')
+        .get('/apps/my-app')
+        .reply(200, app)
+        .get('/apps/my-app/addons')
+        .reply(200, [addon])
+        .get('/apps/my-app/addon-attachments')
+        .reply(200, [addonAttachment])
+        .get('/apps/my-app/config-vars')
+        .reply(200, {
+          HEROKU_APPLINK_API_URL:
+            'https://applink-api.heroku.com/addons/01234567-89ab-cdef-0123-456789abcdef',
+          HEROKU_APPLINK_TOKEN: 'token',
+        })
+        .get('/apps/my-app/addons/01234567-89ab-cdef-0123-456789abcdef/sso')
+        .reply(200, sso_response);
+      applinkApi = nock('https://applink-api.heroku.com');
+    });
+
+    afterEach(function () {
+      process.env = env;
+      api.done();
+      applinkApi.done();
+      nock.cleanAll();
+    });
+
+    it('successfully publishes an API spec file', async function () {
+      applinkApi
+        .post('/addons/01234567-89ab-cdef-0123-456789abcdef/connections/salesforce/myorg/apps')
+        .reply(201, []);
+
+      const filePath = `${__dirname}/../../helpers/openapi.json`;
+
+      const {error} = await runCommand(Cmd, [
+        filePath,
+        '--app=my-app',
+        '--addon=heroku-applink-vertical-01234',
+        '--client-name=AccountAPI',
+        '--connection-name=myorg',
+      ]);
+
+      expect(error).to.not.exist;
+    });
+
+    it('shows deprecation warning when using authorization-connected-app-name flag', async function () {
+      applinkApi
+        .post('/addons/01234567-89ab-cdef-0123-456789abcdef/connections/salesforce/myorg/apps')
+        .reply(201, []);
+
+      const filePath = `${__dirname}/../../helpers/openapi.json`;
+
+      const {stderr} = await runCommand(Cmd, [
+        filePath,
+        '--app=my-app',
+        '--addon=heroku-applink-vertical-01234',
+        '--client-name=AccountAPI',
+        '--connection-name=myorg',
+        '--authorization-connected-app-name=TestApp',
+      ]);
+
+      expect(stderr).to.contain('--authorization-connected-app-name');
+      expect(stderr).to.contain('deprecated');
+      expect(stderr).to.contain('--authorization-external-client-app-name');
+    });
+
+    it('successfully publishes with authorization-external-client-app-name flag', async function () {
+      let capturedBody: string | undefined;
+
+      applinkApi
+        .post('/addons/01234567-89ab-cdef-0123-456789abcdef/connections/salesforce/myorg/apps')
+        .reply(function (_uri, requestBody) {
+          capturedBody
+            = typeof requestBody === 'string'
+              ? Buffer.from(requestBody, 'hex').toString('utf8')
+              : JSON.stringify(requestBody);
+
+          return [201, []];
+        });
+
+      const filePath = `${__dirname}/../../helpers/openapi.json`;
+
+      const {error} = await runCommand(Cmd, [
+        filePath,
+        '--app=my-app',
+        '--addon=heroku-applink-vertical-01234',
+        '--client-name=AccountAPI',
+        '--connection-name=myorg',
+        '--authorization-external-client-app-name=ExternalOAuthApp',
+      ]);
+
+      expect(error).to.not.exist;
+      expect(capturedBody).to.contain('authorization_external_client_app_name');
+      expect(capturedBody).to.contain('ExternalOAuthApp');
+    });
+  });
+
+  it('throws an error when API spec file is not found', async function () {
+    const nonExistentPath = `${__dirname}/non-existent-file.json`;
+
+    const {error} = await runCommand(Cmd, [
+      nonExistentPath,
+      '--app=my-app',
+      '--addon=my-addon',
+      '--client-name=AccountAPI',
+      '--connection-name=myorg',
+    ]);
+
+    expect(error).to.exist;
+    expect(stripAnsi(error!.message)).to.contain(`The API spec file path ${nonExistentPath} doesn't exist.`);
+  });
+
+  it('throws an error when API spec file has invalid format', async function () {
+    const invalidFormatPath = `${__dirname}/../../helpers/invalid.txt`;
+
+    fs.writeFileSync(invalidFormatPath, 'test content');
+
+    try {
+      const {error} = await runCommand(Cmd, [
+        invalidFormatPath,
+        '--app=my-app',
+        '--addon=my-addon',
+        '--client-name=AccountAPI',
+        '--connection-name=myorg',
+      ]);
+
+      expect(error).to.exist;
+      expect(stripAnsi(error!.message)).to.contain('API spec file path must be in YAML (.yaml/.yml) or JSON (.json) format.');
+    } finally {
+      fs.unlinkSync(invalidFormatPath);
+    }
+  });
+
+  it('throws an error when both connectedapp-meta.xml exists and authorization-connected-app-name is provided', async function () {
+    const metadataDir = `${__dirname}/../../helpers/metadata`;
+    const apiSpecPath = `${__dirname}/../../helpers/openapi.json`;
+
+    fs.mkdirSync(metadataDir, {recursive: true});
+    fs.writeFileSync(`${metadataDir}/connectedapp-meta.xml`, '<xml>test</xml>');
+
+    try {
+      const {error} = await runCommand(Cmd, [
+        apiSpecPath,
+        '--app=my-app',
+        '--addon=my-addon',
+        '--client-name=AccountAPI',
+        '--connection-name=myorg',
+        '--metadata-dir',
+        metadataDir,
+        '--authorization-connected-app-name=TestApp',
+      ]);
+
+      expect(error).to.exist;
+      expect(stripAnsi(error!.message)).to.contain('You can only specify the connected app name with connectedapp-meta.xml in the metadata directory'
+          + ' or with the --authorization-connected-app-name flag, not both.');
+    } finally {
+      fs.unlinkSync(`${metadataDir}/connectedapp-meta.xml`);
+      fs.rmdirSync(metadataDir);
+    }
+  });
+
+  it('throws an error when both permissionset-meta.xml exists and authorization-permission-set-name is provided', async function () {
+    const metadataDir = `${__dirname}/../../helpers/metadata`;
+    const apiSpecPath = `${__dirname}/../../helpers/openapi.json`;
+
+    fs.mkdirSync(metadataDir, {recursive: true});
+    fs.writeFileSync(
+      `${metadataDir}/permissionset-meta.xml`,
+      '<xml>test</xml>',
+    );
+
+    try {
+      const {error} = await runCommand(Cmd, [
+        apiSpecPath,
+        '--app=my-app',
+        '--addon=my-addon',
+        '--client-name=AccountAPI',
+        '--connection-name=myorg',
+        '--metadata-dir',
+        metadataDir,
+        '--authorization-permission-set-name=TestPermSet',
+      ]);
+
+      expect(error).to.exist;
+      expect(stripAnsi(error!.message)).to.contain('You can only specify the permission set name with permissionset-meta.xml in the metadata directory'
+          + ' or with the --authorization-permission-set-name flag, not both.');
+    } finally {
+      fs.unlinkSync(`${metadataDir}/permissionset-meta.xml`);
+      fs.rmdirSync(metadataDir);
+    }
+  });
+});

--- a/test/helpers/init.mjs
+++ b/test/helpers/init.mjs
@@ -1,5 +1,6 @@
 import nock from 'nock';
 
+process.env.CI = '1';
 process.env.HEROKU_API_KEY = 'test-api-key';
 process.stdout.columns = 120;
 process.stderr.columns = 120;

--- a/test/helpers/jwtAuthCommandTests.ts
+++ b/test/helpers/jwtAuthCommandTests.ts
@@ -75,7 +75,7 @@ export function createJWTAuthCommandTests(config: JWTAuthTestConfig): void {
           )
           .reply(202, fixtures.authorized);
 
-        const {stderr} = await runCommand(Cmd, [
+        const {error} = await runCommand(Cmd, [
           'my-jwt-auth',
           '--app=my-app',
           '--client-id=test-client-id',
@@ -83,8 +83,7 @@ export function createJWTAuthCommandTests(config: JWTAuthTestConfig): void {
           '--username=admin@applink.org',
         ]);
 
-        expect(stderr).to.contain('Adding credentials for admin@applink.org to my-app as my-jwt-auth');
-        expect(stderr).to.contain('Authorized');
+        expect(error).to.not.exist;
 
         const body = requestBody as {
           alias: string;
@@ -106,7 +105,7 @@ export function createJWTAuthCommandTests(config: JWTAuthTestConfig): void {
           .post(`/addons/01234567-89ab-cdef-0123-456789abcdef/authorizations/${providerName}/jwt`)
           .reply(202, fixtures.failed);
 
-        const {stderr} = await runCommand(Cmd, [
+        const {error} = await runCommand(Cmd, [
           'my-jwt-auth',
           '--app=my-app',
           '--client-id=test-client-id',
@@ -114,8 +113,7 @@ export function createJWTAuthCommandTests(config: JWTAuthTestConfig): void {
           '--username=admin@applink.org',
         ]);
 
-        expect(stderr).to.contain('Adding credentials for admin@applink.org to my-app as my-jwt-auth');
-        expect(stderr).to.contain('Failed');
+        expect(error).to.not.exist;
       });
 
       it('successfully creates JWT authorization with authorizing status', async function () {
@@ -123,7 +121,7 @@ export function createJWTAuthCommandTests(config: JWTAuthTestConfig): void {
           .post(`/addons/01234567-89ab-cdef-0123-456789abcdef/authorizations/${providerName}/jwt`)
           .reply(202, fixtures.authorizing);
 
-        const {stderr} = await runCommand(Cmd, [
+        const {error} = await runCommand(Cmd, [
           'my-jwt-auth',
           '--app=my-app',
           '--client-id=test-client-id',
@@ -131,8 +129,7 @@ export function createJWTAuthCommandTests(config: JWTAuthTestConfig): void {
           '--username=admin@applink.org',
         ]);
 
-        expect(stderr).to.contain('Adding credentials for admin@applink.org to my-app as my-jwt-auth');
-        expect(stderr).to.contain('Authorizing');
+        expect(error).to.not.exist;
       });
     });
 
@@ -149,7 +146,7 @@ export function createJWTAuthCommandTests(config: JWTAuthTestConfig): void {
           )
           .reply(202, fixtures.authorized);
 
-        const {stderr} = await runCommand(Cmd, [
+        const {error} = await runCommand(Cmd, [
           'my-jwt-auth',
           '--app=my-app',
           '--client-id=test-client-id',
@@ -158,8 +155,7 @@ export function createJWTAuthCommandTests(config: JWTAuthTestConfig): void {
           '--login-url=https://test.salesforce.com',
         ]);
 
-        expect(stderr).to.contain('Adding credentials for admin@applink.org to my-app as my-jwt-auth');
-        expect(stderr).to.contain('Authorized');
+        expect(error).to.not.exist;
 
         const body = requestBody as {login_url?: string};
         expect(body.login_url).to.eq('https://test.salesforce.com');
@@ -246,7 +242,7 @@ export function createJWTAuthCommandTests(config: JWTAuthTestConfig): void {
           .post(`/addons/6789abcd-ef01-2345-6789-abcdef012345/authorizations/${providerName}/jwt`)
           .reply(202, fixtures.authorized);
 
-        const {stderr} = await runCommand(Cmd, [
+        const {error} = await runCommand(Cmd, [
           'my-jwt-auth',
           '--app=my-other-app',
           '--addon=heroku-applink-horizontal-01234',
@@ -255,8 +251,7 @@ export function createJWTAuthCommandTests(config: JWTAuthTestConfig): void {
           '--username=admin@applink.org',
         ]);
 
-        expect(stderr).to.contain('Adding credentials for admin@applink.org to my-other-app as my-jwt-auth');
-        expect(stderr).to.contain('Authorized');
+        expect(error).to.not.exist;
 
         multiAddonApi.done();
         multiAddonApplinkApi.done();

--- a/test/lib/applink/types.test.ts
+++ b/test/lib/applink/types.test.ts
@@ -1,6 +1,11 @@
 import {expect} from 'chai';
 
-import {adjustOrgType} from '../../../src/lib/applink/types.js';
+import {
+  adjustOrgType,
+  isDataCloudConnection,
+  isSalesforceConnection,
+} from '../../../src/lib/applink/types.js';
+import {connection1} from '../../helpers/fixtures.js';
 
 describe('applink/types', function () {
   describe('adjustOrgType', function () {
@@ -18,6 +23,18 @@ describe('applink/types', function () {
 
     it('handles undefined', function () {
       expect(adjustOrgType()).to.equal(undefined);
+    });
+  });
+
+  describe('isSalesforceConnection', function () {
+    it('returns true for a SalesforceConnection', function () {
+      expect(isSalesforceConnection(connection1)).to.equal(true);
+    });
+  });
+
+  describe('isDataCloudConnection', function () {
+    it('returns false for a SalesforceConnection', function () {
+      expect(isDataCloudConnection(connection1)).to.equal(false);
     });
   });
 });

--- a/test/lib/applink/types.test.ts
+++ b/test/lib/applink/types.test.ts
@@ -1,0 +1,23 @@
+import {expect} from 'chai';
+
+import {adjustOrgType} from '../../../src/lib/applink/types.js';
+
+describe('applink/types', function () {
+  describe('adjustOrgType', function () {
+    it('normalizes DatacloudOrg to DataCloudOrg', function () {
+      expect(adjustOrgType('DatacloudOrg')).to.equal('DataCloudOrg');
+    });
+
+    it('passes through DataCloudOrg unchanged', function () {
+      expect(adjustOrgType('DataCloudOrg')).to.equal('DataCloudOrg');
+    });
+
+    it('passes through SalesforceOrg unchanged', function () {
+      expect(adjustOrgType('SalesforceOrg')).to.equal('SalesforceOrg');
+    });
+
+    it('handles undefined', function () {
+      expect(adjustOrgType()).to.equal(undefined);
+    });
+  });
+});


### PR DESCRIPTION
<!--
When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`). This is how we manage package versioning and generating CHANGELOG notes.

Examples:
- "feat: add growl notification to spaces:wait"
- "fix: handle special characters in app names"
- "chore: add dist directory to .gitignore"

The expected Conventional Commit types are listed below.

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->

## Summary

<!-- Brief description of the changes in this PR. -->

refactor: As part of larger security work around CLI files, we are upgrading this plugin to oclif v4. In this PR we are also migrating some of applink CLI commands.

Migrating the 8 commands in the following directories to use oclif/core v4, heroku-cli-command v12, and helper functions from heroku-cli-util as needed:

- applink/salesforce
- applink/salesforce/authorizations
- applink/salesforce/connections

This is PR 3 and a branch that will be merged back into the overall feature branch feature/plugin_migration_applink

### Patch Updates (patch semver update)

- [ ] **fix**: Bug fix
- [ ] **perf**: Performance improvement
- [ ] **deps**: Dependency upgrade
- [ ] **revert**: Revert a previous commit
- [x] **docs**: Documentation change
- [x] **style**: Styling update
- [ ] **chore**: Change that does not affect production code
- [x] **refactor**: Refactoring existing code without changing behavior
- [x] **tests**: Add/update/remove tests
- [x] **build**: Change to the build system
- [x] **ci**: Continuous integration workflow update

## Testing

The --help changes (should be limited to --prompt and GLOBAL FLAGS additions that came with cli upgrades):

diff <(./bin/run salesforce:authorizations:add --help) <(heroku salesforce:authorizations:add --help)
diff <(./bin/run salesforce:authorizations:jwt:add --help) <(heroku salesforce:authorizations:jwt:add --help)
diff <(./bin/run salesforce:authorizations:remove --help) <(heroku salesforce:authorizations:remove --help)
diff <(./bin/run salesforce:connect --help) <(heroku salesforce:connect --help)
diff <(./bin/run salesforce:connect:jwt --help) <(heroku salesforce:connect:jwt --help)
diff <(./bin/run salesforce:disconnect --help) <(heroku salesforce:disconnect --help)
diff <(./bin/run salesforce:publications --help) <(heroku salesforce:publications --help)
diff <(./bin/run salesforce:publish --help) <(heroku salesforce:publish --help)

1. Remove salesforce authorization (without confirm meaning you have to confirm it manually)

bin/run salesforce:authorizations:remove my_trailhead_auth -a nodejs-getting-starteeed

2. Add Salesforce authorization (oauth browser flow)

bin/run salesforce:authorizations:add test_auth_1 -a nodejs-getting-starteeed

3. Remove salesforce authorization with --confirm

bin/run salesforce:authorizations:remove test_auth_1 -a nodejs-getting-starteeed --confirm test_auth_1

4. Add Salesforce authorization (oauth browser flow) again because you removed it above

bin/run salesforce:authorizations:add test_auth_1 -a nodejs-getting-starteeed

5. Add Salesforce authorization (oauth browser flow) again because you removed it above

bin/run salesforce:connect test_auth_2 -a nodejs-getting-starteeed

6. Disconnect Salesforce Authorization (skip confirm)

bin/run salesforce:disconnect test_auth_2 -a nodejs-getting-starteeed --confirm=test_auth_2

7. List Publications

bin/run salesforce:publications -a nodejs-getting-starteeed

## Screenshots (if applicable)

## Related Issues

GitHub issue: #[GitHub issue number] GUS work item: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002Yyj3UYAR/view
