### PR TITLE
refactor: Continue Migrating Datacloud Commands PR 4 of 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,22 @@
           }
         }
       },
+      "datacloud": {
+        "description": "manage Heroku app connections to a Data Cloud Org",
+        "subtopics": {
+          "authorizations": {
+            "description": "manage authorizations for connecting Data Cloud orgs to Heroku apps",
+            "subtopics": {
+              "jwt": {
+                "description": "manage JWT-based authorizations for Data Cloud connections"
+              }
+            }
+          },
+          "data-action-target": {
+            "description": "manage data action targets for Data Cloud connections"
+          }
+        }
+      },
       "salesforce": {
         "description": "manage Heroku app connections to a Salesforce Org",
         "subtopics": {

--- a/src/commands/datacloud/authorizations/add.ts
+++ b/src/commands/datacloud/authorizations/add.ts
@@ -1,0 +1,130 @@
+import {flags} from '@heroku-cli/command';
+import * as color from '@heroku/heroku-cli-util/color';
+import {anykey} from '@heroku/heroku-cli-util/hux';
+import {Args} from '@oclif/core';
+import {ux} from '@oclif/core/ux';
+import open from 'open';
+
+import * as AppLink from '../../../lib/applink/types.js';
+import AppLinkCommand from '../../../lib/base.js';
+import {humanize} from '../../../lib/helpers.js';
+
+export default class Add extends AppLinkCommand {
+  public static anykeyHandler: (message?: string) => Promise<string> = anykey;
+  static args = {
+    developer_name: Args.string({
+      description:
+        'unique developer name for the authorization. Must begin with a letter, end with a letter or a number,'
+        + " and between 3-30 characters. Only alphanumeric characters and non-consecutive underscores ('_') are allowed.",
+      required: true,
+    }),
+  };
+  static description
+    = "store a user's credentials for connecting a Data Cloud org to a Heroku app";
+  static flags = {
+    addon: flags.string({
+      description: 'unique name or ID of an AppLink add-on',
+    }),
+    app: flags.app({required: true}),
+    browser: flags.string({
+      description:
+        'browser to open OAuth flow with (example: "firefox", "safari")',
+    }),
+    'login-url': flags.string({
+      char: 'l',
+      description: 'Salesforce login URL',
+    }),
+    remote: flags.remote(),
+    url: flags.boolean({
+      hidden: true,
+    }),
+  };
+  public static urlOpener: (
+    ..._args: Parameters<typeof open>
+  ) => ReturnType<typeof open> = open;
+
+  protected isPendingStatus(status: string): boolean {
+    return status === 'authorizing';
+  }
+
+  public async run(): Promise<void> {
+    const {args, flags} = await this.parse(Add);
+    const {addon, app, browser, 'login-url': loginUrl, url} = flags;
+    const {developer_name: developerName} = args;
+
+    await this.configureAppLinkClient(app, addon);
+    let authorization: AppLink.Authorization;
+    ({body: authorization}
+      = await this.applinkClient.post<AppLink.Authorization>(
+        `/addons/${this.addonId}/authorizations/datacloud`,
+        {
+          body: {
+            developer_name: developerName,
+            login_url: loginUrl,
+          },
+          headers: {authorization: `Bearer ${this._applinkToken}`},
+          retryAuth: false,
+        },
+      ));
+
+    const {id, redirect_uri: redirectUri} = authorization;
+
+    if (url) {
+      ux.stdout(JSON.stringify(redirectUri));
+      return;
+    }
+
+    process.stderr.write(`Opening browser to ${redirectUri}\n`);
+    let urlDisplayed = false;
+    const showBrowserError = () => {
+      if (!urlDisplayed)
+        ux.warn("We can't open the browser. Try again, or use a different browser.");
+      urlDisplayed = true;
+    };
+
+    try {
+      await Add.anykeyHandler(`Press any key to open up the browser to add credentials to ${color.app(app)} as ${color.yellow(developerName)}, or ${color.yellow('q')} to exit`);
+    } catch (error) {
+      const {message} = error as Error;
+      ux.error(message, {exit: 1});
+    }
+
+    const cp = await Add.urlOpener(redirectUri as string, {
+      wait: false,
+      ...(browser ? {app: {name: browser}} : {}),
+    });
+    cp.on('error', (err: Error) => {
+      ux.warn(err);
+      showBrowserError();
+    });
+    cp.on('close', (code: number) => {
+      if (code !== 0) showBrowserError();
+    });
+
+    ux.action.start(`Adding credentials to ${color.app(app)} as ${color.yellow(developerName)}`);
+    let {status} = authorization;
+    ux.action.status = humanize(status);
+
+    /* eslint-disable no-await-in-loop */
+    while (this.isPendingStatus(status)) {
+      await new Promise(resolve => {
+        setTimeout(resolve, 5000);
+      });
+
+      ({body: authorization}
+        = await this.applinkClient.get<AppLink.Authorization>(
+          `/addons/${this.addonId}/authorizations/${id}`,
+          {
+            headers: {authorization: `Bearer ${this._applinkToken}`},
+            retryAuth: false,
+          },
+        ));
+
+      ({status} = authorization);
+      ux.action.status = humanize(status);
+    }
+    /* eslint-enable no-await-in-loop */
+
+    ux.action.stop(humanize(status));
+  }
+}

--- a/src/commands/datacloud/authorizations/jwt/add.ts
+++ b/src/commands/datacloud/authorizations/jwt/add.ts
@@ -1,0 +1,21 @@
+import JWTAuthCommand from '../../../../lib/jwtAuthCommand.js';
+
+export default class JWT extends JWTAuthCommand {
+  static args = JWTAuthCommand.args;
+  static description
+    = "store a user's credentials for connecting a Data Cloud org to a Heroku app using a JWT auth token";
+  static examples = JWTAuthCommand.generateExamples('datacloud:authorizations:jwt:add');
+  static flags = JWTAuthCommand.flags;
+
+  protected get commandName(): string {
+    return 'datacloud:authorizations:jwt:add';
+  }
+
+  protected get providerDisplayName(): string {
+    return 'Data Cloud';
+  }
+
+  protected get providerName(): string {
+    return 'datacloud';
+  }
+}

--- a/src/commands/datacloud/authorizations/remove.ts
+++ b/src/commands/datacloud/authorizations/remove.ts
@@ -1,0 +1,53 @@
+import {flags} from '@heroku-cli/command';
+import * as color from '@heroku/heroku-cli-util/color';
+import {confirmCommand} from '@heroku/heroku-cli-util/hux';
+import {Args} from '@oclif/core';
+import {ux} from '@oclif/core/ux';
+
+import * as AppLink from '../../../lib/applink/types.js';
+import AppLinkCommand from '../../../lib/base.js';
+
+export default class Remove extends AppLinkCommand {
+  static args = {
+    developer_name: Args.string({
+      description: 'developer name of the Data Cloud authorization',
+      required: true,
+    }),
+  };
+  static description = 'remove a Data Cloud authorization from a Heroku app';
+  static flags = {
+    addon: flags.string({
+      description: 'unique name or ID of an AppLink add-on',
+    }),
+    app: flags.app({required: true}),
+    confirm: flags.string({
+      char: 'c',
+      description: 'set to developer name to bypass confirm prompt',
+    }),
+    remote: flags.remote(),
+  };
+
+  public async run(): Promise<void> {
+    const {args, flags} = await this.parse(Remove);
+    const {addon, app, confirm} = flags;
+    const {developer_name: developerName} = args;
+
+    await this.configureAppLinkClient(app, addon);
+
+    await confirmCommand({
+      comparison: developerName,
+      confirmation: confirm,
+      warningMessage: `This command removes the ${color.red(developerName)} credentials from app ${color.app(app)}.`,
+    });
+
+    ux.action.start(`Removing credentials ${color.yellow(developerName)} from ${color.app(app)}`);
+    await this.applinkClient.delete<AppLink.Authorization>(
+      `/addons/${this.addonId}/authorizations/${developerName}`,
+      {
+        headers: {authorization: `Bearer ${this._applinkToken}`},
+        retryAuth: false,
+      },
+    );
+    ux.action.stop();
+  }
+}

--- a/src/commands/datacloud/connect.ts
+++ b/src/commands/datacloud/connect.ts
@@ -1,0 +1,120 @@
+import {flags} from '@heroku-cli/command';
+import * as color from '@heroku/heroku-cli-util/color';
+import {anykey} from '@heroku/heroku-cli-util/hux';
+import {Args} from '@oclif/core';
+import {ux} from '@oclif/core/ux';
+import open from 'open';
+
+import * as AppLink from '../../lib/applink/types.js';
+import AppLinkCommand from '../../lib/base.js';
+import {humanize} from '../../lib/helpers.js';
+
+export default class Connect extends AppLinkCommand {
+  public static anykeyHandler: (message?: string) => Promise<string> = anykey;
+  static args = {
+    connection_name: Args.string({
+      description:
+        'name for the Data Cloud connection. Must begin with a letter, end with a letter or a number,'
+        + " and be between 3-30 characters. Only alphanumeric characters and non-consecutive underscores ('_') are allowed.",
+      required: true,
+    }),
+  };
+  static description = 'connect a Data Cloud org to a Heroku app';
+  static flags = {
+    addon: flags.string({
+      description: 'unique name or ID of an AppLink add-on',
+    }),
+    app: flags.app({required: true}),
+    browser: flags.string({
+      description:
+        'browser to open OAuth flow with (example: "firefox", "safari")',
+    }),
+    'login-url': flags.string({char: 'l', description: 'login URL'}),
+    remote: flags.remote(),
+  };
+  public static urlOpener: (
+    ..._args: Parameters<typeof open>
+  ) => ReturnType<typeof open> = open;
+
+  protected isPendingStatus(status: string): boolean {
+    return (
+      status !== 'connected' && status !== 'failed' && status !== 'disconnected'
+    );
+  }
+
+  public async run(): Promise<void> {
+    const {args, flags} = await this.parse(Connect);
+    const {addon, app, browser, 'login-url': loginUrl} = flags;
+    const {connection_name: connectionName} = args;
+
+    await this.configureAppLinkClient(app, addon);
+    let connection: AppLink.DataCloudConnection;
+    ({body: connection}
+      = await this.applinkClient.post<AppLink.DataCloudConnection>(
+        `/addons/${this.addonId}/connections/datacloud`,
+        {
+          body: {
+            connection_name: connectionName,
+            login_url: loginUrl,
+          },
+          headers: {authorization: `Bearer ${this._applinkToken}`},
+          retryAuth: false,
+        },
+      ));
+
+    const {id, redirect_uri: redirectUri} = connection;
+
+    process.stderr.write(`Opening browser to ${redirectUri}\n`);
+    let urlDisplayed = false;
+    const showBrowserError = () => {
+      if (!urlDisplayed)
+        ux.warn("We can't open the browser. Try again, or use a different browser.");
+      urlDisplayed = true;
+    };
+
+    try {
+      await Connect.anykeyHandler(`Press any key to open up the browser to connect ${color.app(app)} to ${color.yellow(connectionName)}, or ${color.yellow('q')} to exit`);
+    } catch (error) {
+      const {message} = error as Error;
+      ux.error(message, {exit: 1});
+    }
+
+    const cp = await Connect.urlOpener(redirectUri as string, {
+      wait: false,
+      ...(browser ? {app: {name: browser}} : {}),
+    });
+    cp.on('error', (err: Error) => {
+      ux.warn(err);
+      showBrowserError();
+    });
+    cp.on('close', (code: number) => {
+      if (code !== 0) showBrowserError();
+    });
+
+    ux.action.start(`Connecting Data Cloud org to ${color.app(app)} as ${color.yellow(connectionName)}`);
+    let {status} = connection;
+    ux.action.status = humanize(status);
+
+    /* eslint-disable no-await-in-loop */
+    while (this.isPendingStatus(status)) {
+      await new Promise(resolve => {
+        setTimeout(resolve, 5000);
+      });
+
+      ({body: connection}
+        = await this.applinkClient.get<AppLink.DataCloudConnection>(
+          `/addons/${this.addonId}/connections/${id}`,
+          {
+            headers: {authorization: `Bearer ${this._applinkToken}`},
+            retryAuth: false,
+          },
+        ));
+
+      ({status} = connection);
+      ux.action.status = humanize(status);
+    }
+    /* eslint-enable no-await-in-loop */
+
+    ux.action.stop(humanize(status));
+  }
+}

--- a/src/commands/datacloud/data-action-target/create.ts
+++ b/src/commands/datacloud/data-action-target/create.ts
@@ -1,0 +1,115 @@
+import {flags} from '@heroku-cli/command';
+import * as color from '@heroku/heroku-cli-util/color';
+import {Args} from '@oclif/core';
+import {ux} from '@oclif/core/ux';
+
+import * as AppLink from '../../../lib/applink/types.js';
+import AppLinkCommand from '../../../lib/base.js';
+import {humanize} from '../../../lib/helpers.js';
+
+export default class Create extends AppLinkCommand {
+  static args = {
+    label: Args.string({
+      description:
+        'label for the data action target. Must begin with a letter, end with a letter or a number,'
+        + " and between 3-30 characters. Only alphanumeric characters and non-consecutive underscores ('_') are allowed.",
+      required: true,
+    }),
+  };
+  static description
+    = 'create a Data Cloud data action target for a Heroku app';
+  static flags = {
+    addon: flags.string({
+      description: 'unique name or ID of an AppLink add-on',
+    }),
+    'api-name': flags.string({
+      char: 'n',
+      description: '[default: <LABEL>] API name for the data action target',
+    }),
+    app: flags.app({required: true}),
+    'connection-name': flags.string({
+      char: 'o',
+      description:
+        'Data Cloud connection name to create the data action target',
+      required: true,
+    }),
+    remote: flags.remote(),
+    'target-api-path': flags.string({
+      char: 'p',
+      description:
+        'API path for the data action target excluding app URL, eg "/" or "/handleDataCloudDataChangeEvent"',
+      required: true,
+    }),
+    type: flags.string({
+      char: 't',
+      default: 'webhook',
+      description: 'Data action target type',
+      options: ['webhook'],
+    }),
+  };
+
+  protected isPendingStatus(status: string): boolean {
+    return status !== 'created' && status !== 'creation_failed';
+  }
+
+  public async run(): Promise<void> {
+    const {args, flags} = await this.parse(Create);
+    const {
+      addon,
+      app,
+      'connection-name': connectionName,
+      'target-api-path': targetPath,
+      type,
+    } = flags;
+    let {'api-name': apiName} = flags;
+    const {label} = args;
+
+    if (!apiName) {
+      apiName = label.replaceAll(' ', '_');
+    }
+
+    await this.configureAppLinkClient(app, addon);
+
+    ux.action.start(`Creating ${color.app(app)} as '${color.yellow(label)}' data action target ${type} to ${color.yellow(connectionName)}`);
+
+    const {body: createResp}
+      = await this.applinkClient.post<AppLink.DataActionTargetCreate>(
+        `/addons/${this.addonId}/connections/datacloud/${connectionName}/data_action_targets`,
+        {
+          body: {
+            api_name: apiName,
+            label,
+            target_endpoint: targetPath,
+            type,
+          },
+          headers: {authorization: `Bearer ${this._applinkToken}`},
+          retryAuth: false,
+        },
+      );
+
+    let {status} = createResp;
+    let createStatus: AppLink.DataActionTargetCreate;
+
+    /* eslint-disable no-await-in-loop */
+    while (this.isPendingStatus(status)) {
+      await new Promise(resolve => {
+        setTimeout(resolve, 5000);
+      });
+
+      ({body: createStatus}
+        = await this.applinkClient.get<AppLink.DataActionTargetCreate>(
+          `/addons/${this.addonId}/connections/datacloud/${connectionName}/data_action_targets/${apiName}`,
+          {
+            headers: {authorization: `Bearer ${this._applinkToken}`},
+            retryAuth: false,
+          },
+        ));
+
+      status = createStatus.status;
+      ux.action.status = humanize(status);
+    }
+    /* eslint-enable no-await-in-loop */
+
+    ux.action.stop(humanize(status));
+  }
+}

--- a/src/commands/datacloud/disconnect.ts
+++ b/src/commands/datacloud/disconnect.ts
@@ -1,0 +1,98 @@
+import {flags} from '@heroku-cli/command';
+import * as color from '@heroku/heroku-cli-util/color';
+import {confirmCommand} from '@heroku/heroku-cli-util/hux';
+import {Args} from '@oclif/core';
+import {ux} from '@oclif/core/ux';
+import tsheredoc from 'tsheredoc';
+
+import * as AppLink from '../../lib/applink/types.js';
+import AppLinkCommand from '../../lib/base.js';
+import {humanize} from '../../lib/helpers.js';
+
+const heredoc = tsheredoc.default ?? tsheredoc;
+
+export default class Disconnect extends AppLinkCommand {
+  static args = {
+    connection_name: Args.string({
+      description: 'name of the Data Cloud connection',
+      required: true,
+    }),
+  };
+  static description = 'disconnect a Data Cloud org from a Heroku app';
+  static flags = {
+    addon: flags.string({
+      description: 'unique name or ID of an AppLink add-on',
+    }),
+    app: flags.app({required: true}),
+    confirm: flags.string({
+      char: 'c',
+      description:
+        'set to Data Cloud org connection name to bypass confirm prompt',
+    }),
+    remote: flags.remote(),
+  };
+
+  public async run(): Promise<void> {
+    const {args, flags} = await this.parse(Disconnect);
+    const {addon, app, confirm} = flags;
+    const {connection_name: connectionName} = args;
+
+    await this.configureAppLinkClient(app, addon);
+
+    let dataActionTargets: AppLink.DataActionTarget[] = [];
+
+    try {
+      const {body} = await this.applinkClient.get<AppLink.DataActionTarget[]>(
+        `/addons/${this.addonId}/connections/datacloud/${connectionName}/data_action_targets`,
+        {
+          headers: {authorization: `Bearer ${this._applinkToken}`},
+          retryAuth: false,
+        },
+      );
+      dataActionTargets = body || [];
+    } catch {
+      ux.error('Failed to fetch data action targets for connection', {
+        exit: 1,
+      });
+    }
+
+    let warningMessage: string | undefined;
+    if (dataActionTargets.length > 0) {
+      const targetNames = dataActionTargets.map(t => t.label).join('\n  ');
+      warningMessage = heredoc`
+        This command disconnects the org ${connectionName} from add-on ${this._addonName} on app ${app} and deletes the following data action targets:
+          ${targetNames}`;
+    }
+
+    await confirmCommand({
+      comparison: connectionName,
+      confirmation: confirm,
+      warningMessage,
+    });
+
+    try {
+      await this.applinkClient.delete<AppLink.DataCloudConnection>(
+        `/addons/${this.addonId}/connections/${connectionName}`,
+        {
+          headers: {authorization: `Bearer ${this._applinkToken}`},
+          retryAuth: false,
+        },
+      );
+    } catch (error) {
+      const connErr = error as AppLink.ConnectionError;
+      if (connErr.body && connErr.body.id === 'record_not_found') {
+        ux.error(
+          heredoc`
+            Data Cloud connection ${color.yellow(connectionName)} doesn't exist on app ${color.app(app)}.
+            Use ${color.command(`heroku applink:connections --app ${app}`)} to list the connections on the app`,
+          {exit: 1},
+        );
+      } else {
+        throw error;
+      }
+    }
+
+    ux.action.start(`Disconnecting Data Cloud connection ${color.yellow(connectionName)} from ${color.app(app)}`);
+    ux.action.stop(humanize('Disconnected'));
+  }
+}

--- a/test/commands/datacloud/authorizations/add.test.ts
+++ b/test/commands/datacloud/authorizations/add.test.ts
@@ -1,2 +1,171 @@
-// This test will be migrated in a subsequent PR.
-export {};
+import {runCommand} from '@heroku-cli/test-utils';
+import {expect} from 'chai';
+import nock from 'nock';
+import {ChildProcess} from 'node:child_process';
+import sinon, {SinonSandbox, SinonStub} from 'sinon';
+
+import Cmd from '../../../../src/commands/datacloud/authorizations/add.js';
+import {
+  addon,
+  addonAttachment,
+  app,
+  authorization_authenticating,
+  authorization_connected,
+  authorization_connection_failed,
+  authorization_disconnected,
+  sso_response,
+} from '../../../helpers/fixtures.js';
+import stripAnsi from '../../../helpers/strip-ansi.js';
+
+describe('datacloud:authorizations:add', function () {
+  let api: nock.Scope;
+  let applinkApi: nock.Scope;
+  const {env} = process;
+  let sandbox: SinonSandbox;
+  let urlOpener: SinonStub;
+
+  beforeEach(function () {
+    process.env = {};
+    api = nock('https://api.heroku.com')
+      .get('/apps/my-app')
+      .reply(200, app)
+      .get('/apps/my-app/addons')
+      .reply(200, [addon])
+      .get('/apps/my-app/addon-attachments')
+      .reply(200, [addonAttachment])
+      .get('/apps/my-app/config-vars')
+      .reply(200, {
+        HEROKU_APPLINK_API_URL:
+          'https://applink-api.heroku.com/addons/01234567-89ab-cdef-0123-456789abcdef',
+        HEROKU_APPLINK_TOKEN: 'token',
+      })
+      .get('/apps/my-app/addons/01234567-89ab-cdef-0123-456789abcdef/sso')
+      .reply(200, sso_response);
+    applinkApi = nock('https://applink-api.heroku.com');
+    sandbox = sinon.createSandbox();
+  });
+
+  afterEach(function () {
+    process.env = env;
+    api.done();
+    applinkApi.done();
+    nock.cleanAll();
+    sandbox.restore();
+  });
+
+  context('when the user accepts the prompt to open the browser', function () {
+    beforeEach(function () {
+      urlOpener = sandbox
+        .stub(Cmd, 'urlOpener')
+        .onFirstCall()
+        .resolves({
+          on(_: string, _cb: (_err: Error) => void) {},
+        } as unknown as ChildProcess);
+      sandbox.stub(Cmd, 'anykeyHandler').resolves('');
+      applinkApi
+        .post('/addons/01234567-89ab-cdef-0123-456789abcdef/authorizations/datacloud')
+        .reply(202, authorization_authenticating);
+    });
+
+    context('when the authorization succeeds', function () {
+      beforeEach(function () {
+        applinkApi
+          .get('/addons/01234567-89ab-cdef-0123-456789abcdef/authorizations/5551fe92-c2fb-4ef7-be43-9d927d9a5c53')
+          .reply(200, authorization_connected);
+      });
+
+      it('shows the URL that will be opened for the OAuth flow', async function () {
+        const {stderr} = await runCommand(Cmd, ['my-auth-1', '--app=my-app']);
+
+        expect(stderr).to.contain(`Opening browser to ${authorization_authenticating.redirect_uri}`);
+      });
+
+      it('attempts to open the browser to the redirect URI', async function () {
+        await runCommand(Cmd, ['my-auth-1', '--app=my-app']);
+
+        expect(urlOpener.calledWith(authorization_authenticating.redirect_uri, {
+          wait: false,
+        })).to.equal(true);
+      });
+
+      it('shows the expected output after connecting', async function () {
+        const {stderr} = await runCommand(Cmd, ['my-auth-1', '--app=my-app']);
+
+        expect(stripAnsi(stderr)).to.contain('Adding credentials to my-app as my-auth-1');
+        expect(stripAnsi(stderr)).to.contain('Authorized');
+      });
+    });
+
+    context('when the authorization fails', function () {
+      it('completes polling when authorization status is disconnected', async function () {
+        applinkApi
+          .get('/addons/01234567-89ab-cdef-0123-456789abcdef/authorizations/5551fe92-c2fb-4ef7-be43-9d927d9a5c53')
+          .reply(200, authorization_connection_failed);
+
+        const {error} = await runCommand(Cmd, ['my-auth-1', '--app=my-app']);
+
+        expect(error).to.not.exist;
+      });
+
+      it('completes polling when authorization is disconnected without error', async function () {
+        applinkApi
+          .get('/addons/01234567-89ab-cdef-0123-456789abcdef/authorizations/5551fe92-c2fb-4ef7-be43-9d927d9a5c53')
+          .reply(200, authorization_disconnected);
+
+        const {error} = await runCommand(Cmd, ['my-auth-1', '--app=my-app']);
+
+        expect(error).to.not.exist;
+      });
+    });
+  });
+
+  context('when the user rejects the prompt to open the browser', function () {
+    beforeEach(function () {
+      urlOpener = sandbox.stub(Cmd, 'urlOpener');
+      sandbox.stub(Cmd, 'anykeyHandler').rejects(new Error('quit'));
+      applinkApi
+        .post('/addons/01234567-89ab-cdef-0123-456789abcdef/authorizations/datacloud')
+        .reply(202, authorization_authenticating);
+    });
+
+    it("doesn't attempt to open the browser to the redirect URI", async function () {
+      await runCommand(Cmd, ['my-auth-1', '--app=my-app']);
+
+      expect(urlOpener.notCalled).to.equal(true);
+    });
+  });
+
+  context('when the --url flag is provided', function () {
+    let anykeyStub: SinonStub;
+
+    beforeEach(function () {
+      urlOpener = sandbox.stub(Cmd, 'urlOpener');
+      anykeyStub = sandbox.stub(Cmd, 'anykeyHandler');
+      applinkApi
+        .post('/addons/01234567-89ab-cdef-0123-456789abcdef/authorizations/datacloud')
+        .reply(202, authorization_authenticating);
+    });
+
+    it('outputs the redirect URI', async function () {
+      const {stdout} = await runCommand(Cmd, [
+        'my-auth-1',
+        '--app=my-app',
+        '--url',
+      ]);
+
+      expect(stdout).to.contain(authorization_authenticating.redirect_uri!);
+    });
+
+    it("doesn't prompt the user to open the browser", async function () {
+      await runCommand(Cmd, ['my-auth-1', '--app=my-app', '--url']);
+
+      expect(anykeyStub.notCalled).to.equal(true);
+    });
+
+    it("doesn't attempt to open the browser", async function () {
+      await runCommand(Cmd, ['my-auth-1', '--app=my-app', '--url']);
+
+      expect(urlOpener.notCalled).to.equal(true);
+    });
+  });
+});

--- a/test/commands/datacloud/authorizations/add/jwt.test.ts
+++ b/test/commands/datacloud/authorizations/add/jwt.test.ts
@@ -1,2 +1,17 @@
-// This test will be migrated in a subsequent PR.
-export {};
+import Cmd from '../../../../../src/commands/datacloud/authorizations/jwt/add.js';
+import {
+  authorization_datacloud_jwt_authorized,
+  authorization_datacloud_jwt_authorizing,
+  authorization_datacloud_jwt_failed,
+} from '../../../../helpers/fixtures.js';
+import {createJWTAuthCommandTests} from '../../../../helpers/jwtAuthCommandTests.js';
+
+createJWTAuthCommandTests({
+  commandClass: Cmd,
+  fixtures: {
+    authorized: authorization_datacloud_jwt_authorized,
+    authorizing: authorization_datacloud_jwt_authorizing,
+    failed: authorization_datacloud_jwt_failed,
+  },
+  providerName: 'datacloud',
+});

--- a/test/commands/datacloud/authorizations/remove.test.ts
+++ b/test/commands/datacloud/authorizations/remove.test.ts
@@ -1,2 +1,59 @@
-// This test will be migrated in a subsequent PR.
-export {};
+import {runCommand} from '@heroku-cli/test-utils';
+import {expect} from 'chai';
+import nock from 'nock';
+
+import Cmd from '../../../../src/commands/datacloud/authorizations/remove.js';
+import {
+  addon,
+  addonAttachment,
+  app,
+  sso_response,
+} from '../../../helpers/fixtures.js';
+
+describe('datacloud:authorizations:remove', function () {
+  let api: nock.Scope;
+  let applinkApi: nock.Scope;
+  const {env} = process;
+
+  beforeEach(function () {
+    process.env = {};
+    api = nock('https://api.heroku.com')
+      .get('/apps/my-app')
+      .reply(200, app)
+      .get('/apps/my-app/addons')
+      .reply(200, [addon])
+      .get('/apps/my-app/addon-attachments')
+      .reply(200, [addonAttachment])
+      .get('/apps/my-app/config-vars')
+      .reply(200, {
+        HEROKU_APPLINK_API_URL:
+          'https://applink-api.heroku.com/addons/01234567-89ab-cdef-0123-456789abcdef',
+        HEROKU_APPLINK_TOKEN: 'token',
+      })
+      .get('/apps/my-app/addons/01234567-89ab-cdef-0123-456789abcdef/sso')
+      .reply(200, sso_response);
+    applinkApi = nock('https://applink-api.heroku.com');
+  });
+
+  afterEach(function () {
+    process.env = env;
+    api.done();
+    applinkApi.done();
+    nock.cleanAll();
+  });
+
+  it('successfully removes a Data Cloud authorization from a Heroku app', async function () {
+    applinkApi
+      .delete('/addons/01234567-89ab-cdef-0123-456789abcdef/authorizations/my-auth-1')
+      .reply(200, {});
+
+    const {error} = await runCommand(Cmd, [
+      'my-auth-1',
+      '--app=my-app',
+      '--addon=heroku-applink-vertical-01234',
+      '--confirm=my-auth-1',
+    ]);
+
+    expect(error).to.not.exist;
+  });
+});

--- a/test/commands/datacloud/connect.test.ts
+++ b/test/commands/datacloud/connect.test.ts
@@ -1,2 +1,158 @@
-// This test will be migrated in a subsequent PR.
-export {};
+import {runCommand} from '@heroku-cli/test-utils';
+import {expect} from 'chai';
+import nock from 'nock';
+import {ChildProcess} from 'node:child_process';
+import sinon, {SinonSandbox, SinonStub} from 'sinon';
+
+import Cmd from '../../../src/commands/datacloud/connect.js';
+import {
+  addon,
+  addonAttachment,
+  app,
+  connection4_connected,
+  connection4_connecting,
+  connection4_disconnected,
+  connection4_failed,
+  sso_response,
+} from '../../helpers/fixtures.js';
+import stripAnsi from '../../helpers/strip-ansi.js';
+
+describe('datacloud:connect', function () {
+  let api: nock.Scope;
+  const {env} = process;
+  let sandbox: SinonSandbox;
+  let urlOpener: SinonStub;
+
+  context('when config var is set to HEROKU_APPLINK_API_URL', function () {
+    let applinkApi: nock.Scope;
+
+    beforeEach(function () {
+      process.env = {};
+      api = nock('https://api.heroku.com')
+        .get('/apps/my-app')
+        .reply(200, app)
+        .get('/apps/my-app/addons')
+        .reply(200, [addon])
+        .get('/apps/my-app/addon-attachments')
+        .reply(200, [addonAttachment])
+        .get('/apps/my-app/config-vars')
+        .reply(200, {
+          HEROKU_APPLINK_API_URL:
+            'https://applink-api.heroku.com/addons/01234567-89ab-cdef-0123-456789abcdef',
+          HEROKU_APPLINK_TOKEN: 'token',
+        })
+        .get('/apps/my-app/addons/01234567-89ab-cdef-0123-456789abcdef/sso')
+        .reply(200, sso_response);
+      applinkApi = nock('https://applink-api.heroku.com');
+      sandbox = sinon.createSandbox();
+    });
+
+    afterEach(function () {
+      process.env = env;
+      api.done();
+      applinkApi.done();
+      nock.cleanAll();
+      sandbox.restore();
+    });
+
+    context(
+      'when the user accepts the prompt to open the browser',
+      function () {
+        beforeEach(function () {
+          urlOpener = sandbox
+            .stub(Cmd, 'urlOpener')
+            .onFirstCall()
+            .resolves({
+              on(_: string, _cb: (_err: Error) => void) {},
+            } as unknown as ChildProcess);
+          sandbox.stub(Cmd, 'anykeyHandler').resolves('');
+          applinkApi
+            .post('/addons/01234567-89ab-cdef-0123-456789abcdef/connections/datacloud')
+            .reply(202, connection4_connecting);
+        });
+
+        context('when the connection succeeds', function () {
+          beforeEach(function () {
+            applinkApi
+              .get('/addons/01234567-89ab-cdef-0123-456789abcdef/connections/339b373a-5d0c-4056-bfdd-47a06b79f112')
+              .reply(200, connection4_connected);
+          });
+
+          it('shows the URL that will be opened for the OAuth flow', async function () {
+            const {stderr} = await runCommand(Cmd, [
+              'my-org-2',
+              '--app=my-app',
+            ]);
+
+            expect(stderr).to.contain(`Opening browser to ${connection4_connecting.redirect_uri}`);
+          });
+
+          it('attempts to open the browser to the redirect URI', async function () {
+            await runCommand(Cmd, ['my-org-2', '--app=my-app']);
+
+            expect(urlOpener.calledWith(connection4_connecting.redirect_uri, {
+              wait: false,
+            })).to.equal(true);
+          });
+
+          it('shows the expected output after connecting', async function () {
+            const {stderr} = await runCommand(Cmd, [
+              'my-org-2',
+              '--app=my-app',
+            ]);
+
+            expect(stripAnsi(stderr)).to.contain('Connecting Data Cloud org to my-app as my-org-2');
+            expect(stripAnsi(stderr)).to.contain('Connected');
+          });
+        });
+
+        context('when the connection fails', function () {
+          it('completes polling when connection fails', async function () {
+            applinkApi
+              .get('/addons/01234567-89ab-cdef-0123-456789abcdef/connections/339b373a-5d0c-4056-bfdd-47a06b79f112')
+              .reply(200, connection4_failed);
+
+            const {error} = await runCommand(Cmd, [
+              'my-org-2',
+              '--app=my-app',
+            ]);
+
+            expect(error).to.not.exist;
+          });
+
+          it('completes polling when connection is disconnected', async function () {
+            applinkApi
+              .get('/addons/01234567-89ab-cdef-0123-456789abcdef/connections/339b373a-5d0c-4056-bfdd-47a06b79f112')
+              .reply(200, connection4_disconnected);
+
+            const {error} = await runCommand(Cmd, [
+              'my-org-2',
+              '--app=my-app',
+            ]);
+
+            expect(error).to.not.exist;
+          });
+        });
+      },
+    );
+
+    context(
+      'when the user rejects the prompt to open the browser',
+      function () {
+        beforeEach(function () {
+          urlOpener = sandbox.stub(Cmd, 'urlOpener');
+          sandbox.stub(Cmd, 'anykeyHandler').rejects(new Error('quit'));
+          applinkApi
+            .post('/addons/01234567-89ab-cdef-0123-456789abcdef/connections/datacloud')
+            .reply(202, connection4_connecting);
+        });
+
+        it("doesn't attempt to open the browser to the redirect URI", async function () {
+          await runCommand(Cmd, ['my-org-2', '--app=my-app']);
+
+          expect(urlOpener.notCalled).to.equal(true);
+        });
+      },
+    );
+  });
+});

--- a/test/commands/datacloud/data-action-taget/create.test.ts
+++ b/test/commands/datacloud/data-action-taget/create.test.ts
@@ -1,2 +1,0 @@
-// This test will be migrated in a subsequent PR.
-export {};

--- a/test/commands/datacloud/data-action-target/create.test.ts
+++ b/test/commands/datacloud/data-action-target/create.test.ts
@@ -1,0 +1,183 @@
+import {runCommand} from '@heroku-cli/test-utils';
+import {expect} from 'chai';
+import nock from 'nock';
+
+import Cmd from '../../../../src/commands/datacloud/data-action-target/create.js';
+import {
+  addon,
+  addonAttachment,
+  app,
+  datCreateFailed,
+  datCreatePending,
+  datCreateSuccess,
+  sso_response,
+} from '../../../helpers/fixtures.js';
+import stripAnsi from '../../../helpers/strip-ansi.js';
+
+describe('datacloud:data-action-target:create', function () {
+  let api: nock.Scope;
+  let applinkApi: nock.Scope;
+  const {env} = process;
+
+  beforeEach(function () {
+    process.env = {};
+    api = nock('https://api.heroku.com')
+      .get('/apps/my-app')
+      .reply(200, app)
+      .get('/apps/my-app/addons')
+      .reply(200, [addon])
+      .get('/apps/my-app/addon-attachments')
+      .reply(200, [addonAttachment])
+      .get('/apps/my-app/config-vars')
+      .reply(200, {
+        HEROKU_APPLINK_API_URL:
+          'https://applink-api.heroku.com/addons/01234567-89ab-cdef-0123-456789abcdef',
+        HEROKU_APPLINK_TOKEN: 'token',
+      })
+      .get('/apps/my-app/addons/01234567-89ab-cdef-0123-456789abcdef/sso')
+      .reply(200, sso_response);
+    applinkApi = nock('https://applink-api.heroku.com');
+  });
+
+  afterEach(function () {
+    process.env = env;
+    api.done();
+    applinkApi.done();
+    nock.cleanAll();
+  });
+
+  it('creates a data action target successfully when status is immediately created', async function () {
+    applinkApi
+      .post('/addons/01234567-89ab-cdef-0123-456789abcdef/connections/datacloud/productionOrg/data_action_targets')
+      .reply(202, datCreateSuccess);
+
+    const {error, stderr} = await runCommand(Cmd, [
+      'My Data Action Target',
+      '--app=my-app',
+      '--connection-name=productionOrg',
+      '--target-api-path=/handleDataCloudDataChangeEvent',
+    ]);
+
+    expect(error).to.not.exist;
+    expect(stripAnsi(stderr)).to.contain('Created');
+  });
+
+  it('polls until status is created', async function () {
+    applinkApi
+      .post('/addons/01234567-89ab-cdef-0123-456789abcdef/connections/datacloud/productionOrg/data_action_targets')
+      .reply(202, datCreatePending);
+    applinkApi
+      .get('/addons/01234567-89ab-cdef-0123-456789abcdef/connections/datacloud/productionOrg/data_action_targets/MyDataActionTarget')
+      .reply(200, datCreateSuccess);
+
+    const {error} = await runCommand(Cmd, [
+      'My Data Action Target',
+      '--app=my-app',
+      '--connection-name=productionOrg',
+      '--target-api-path=/handleDataCloudDataChangeEvent',
+      '--api-name=MyDataActionTarget',
+    ]);
+
+    expect(error).to.not.exist;
+  });
+
+  it('stops polling when creation fails', async function () {
+    applinkApi
+      .post('/addons/01234567-89ab-cdef-0123-456789abcdef/connections/datacloud/productionOrg/data_action_targets')
+      .reply(202, datCreatePending);
+    applinkApi
+      .get('/addons/01234567-89ab-cdef-0123-456789abcdef/connections/datacloud/productionOrg/data_action_targets/MyDataActionTarget')
+      .reply(200, datCreateFailed);
+
+    const {error, stderr} = await runCommand(Cmd, [
+      'My Data Action Target',
+      '--app=my-app',
+      '--connection-name=productionOrg',
+      '--target-api-path=/handleDataCloudDataChangeEvent',
+      '--api-name=MyDataActionTarget',
+    ]);
+
+    expect(error).to.not.exist;
+    expect(stripAnsi(stderr)).to.contain('Creation Failed');
+  });
+
+  it('uses label as api-name when --api-name is not provided', async function () {
+    let requestBody: unknown;
+    applinkApi
+      .post(
+        '/addons/01234567-89ab-cdef-0123-456789abcdef/connections/datacloud/productionOrg/data_action_targets',
+        (body: unknown) => {
+          requestBody = body;
+          return true;
+        },
+      )
+      .reply(202, datCreateSuccess);
+
+    await runCommand(Cmd, [
+      'My Data Action Target',
+      '--app=my-app',
+      '--connection-name=productionOrg',
+      '--target-api-path=/handleDataCloudDataChangeEvent',
+    ]);
+
+    const body = requestBody as {api_name: string};
+    expect(body.api_name).to.eq('My_Data_Action_Target');
+  });
+
+  it('uses the provided --api-name flag', async function () {
+    let requestBody: unknown;
+    applinkApi
+      .post(
+        '/addons/01234567-89ab-cdef-0123-456789abcdef/connections/datacloud/productionOrg/data_action_targets',
+        (body: unknown) => {
+          requestBody = body;
+          return true;
+        },
+      )
+      .reply(202, datCreateSuccess);
+
+    await runCommand(Cmd, [
+      'My Data Action Target',
+      '--app=my-app',
+      '--connection-name=productionOrg',
+      '--target-api-path=/handleDataCloudDataChangeEvent',
+      '--api-name=CustomApiName',
+    ]);
+
+    const body = requestBody as {api_name: string};
+    expect(body.api_name).to.eq('CustomApiName');
+  });
+
+  it('sends correct request body fields', async function () {
+    let requestBody: unknown;
+    applinkApi
+      .post(
+        '/addons/01234567-89ab-cdef-0123-456789abcdef/connections/datacloud/productionOrg/data_action_targets',
+        (body: unknown) => {
+          requestBody = body;
+          return true;
+        },
+      )
+      .reply(202, datCreateSuccess);
+
+    await runCommand(Cmd, [
+      'My Data Action Target',
+      '--app=my-app',
+      '--connection-name=productionOrg',
+      '--target-api-path=/handleDataCloudDataChangeEvent',
+      '--type=webhook',
+      '--api-name=MyDAT',
+    ]);
+
+    const body = requestBody as {
+      api_name: string;
+      label: string;
+      target_endpoint: string;
+      type: string;
+    };
+    expect(body.label).to.eq('My Data Action Target');
+    expect(body.api_name).to.eq('MyDAT');
+    expect(body.target_endpoint).to.eq('/handleDataCloudDataChangeEvent');
+    expect(body.type).to.eq('webhook');
+  });
+});

--- a/test/commands/datacloud/disconnect.test.ts
+++ b/test/commands/datacloud/disconnect.test.ts
@@ -1,2 +1,201 @@
-// This test will be migrated in a subsequent PR.
-export {};
+import {runCommand} from '@heroku-cli/test-utils';
+import {expect} from 'chai';
+import nock from 'nock';
+
+import Cmd from '../../../src/commands/datacloud/disconnect.js';
+import {
+  addon,
+  addon2,
+  addonAttachment,
+  addonAttachment2,
+  app,
+  connection5_disconnecting,
+  ConnectionError_record_not_found,
+  sso_response,
+} from '../../helpers/fixtures.js';
+import stripAnsi from '../../helpers/strip-ansi.js';
+
+describe('datacloud:disconnect', function () {
+  let api: nock.Scope;
+  let applinkApi: nock.Scope;
+  const {env} = process;
+
+  context('when config var is set to HEROKU_APPLINK_API_URL', function () {
+    beforeEach(function () {
+      process.env = {};
+      api = nock('https://api.heroku.com')
+        .get('/apps/my-app')
+        .reply(200, app)
+        .get('/apps/my-app/addons')
+        .reply(200, [addon])
+        .get('/apps/my-app/addon-attachments')
+        .reply(200, [addonAttachment])
+        .get('/apps/my-app/config-vars')
+        .reply(200, {
+          HEROKU_APPLINK_API_URL:
+            'https://applink-api.heroku.com/addons/01234567-89ab-cdef-0123-456789abcdef',
+          HEROKU_APPLINK_TOKEN: 'token',
+        })
+        .get('/apps/my-app/addons/01234567-89ab-cdef-0123-456789abcdef/sso')
+        .reply(200, sso_response);
+      applinkApi = nock('https://applink-api.heroku.com');
+    });
+
+    afterEach(function () {
+      process.env = env;
+      api.done();
+      applinkApi.done();
+      nock.cleanAll();
+    });
+
+    it('disconnects successfully when no data action targets exist', async function () {
+      applinkApi
+        .get('/addons/01234567-89ab-cdef-0123-456789abcdef/connections/datacloud/myorg/data_action_targets')
+        .reply(200, []);
+      applinkApi
+        .delete('/addons/01234567-89ab-cdef-0123-456789abcdef/connections/myorg')
+        .reply(202, connection5_disconnecting);
+
+      const {stderr} = await runCommand(Cmd, [
+        'myorg',
+        '--app=my-app',
+        '--confirm=myorg',
+      ]);
+
+      expect(stderr).to.contain('Disconnected');
+    });
+
+    it('disconnects successfully when data action targets exist', async function () {
+      applinkApi
+        .get('/addons/01234567-89ab-cdef-0123-456789abcdef/connections/datacloud/myorg/data_action_targets')
+        .reply(200, [
+          {
+            api_name: 'MyDAT',
+            app_id: 'app-1',
+            connection_id: 'conn-1',
+            id: 'dat-1',
+            label: 'My Data Action Target',
+            status: 'created',
+            target_endpoint: '/handle',
+            type: 'webhook',
+          },
+        ]);
+      applinkApi
+        .delete('/addons/01234567-89ab-cdef-0123-456789abcdef/connections/myorg')
+        .reply(202, connection5_disconnecting);
+
+      const {stderr} = await runCommand(Cmd, [
+        'myorg',
+        '--app=my-app',
+        '--confirm=myorg',
+      ]);
+
+      expect(stderr).to.contain('Disconnected');
+    });
+
+    it('connection not found', async function () {
+      applinkApi
+        .get('/addons/01234567-89ab-cdef-0123-456789abcdef/connections/datacloud/myorg/data_action_targets')
+        .reply(200, []);
+      applinkApi
+        .delete('/addons/01234567-89ab-cdef-0123-456789abcdef/connections/myorg')
+        .reply(404, ConnectionError_record_not_found.body);
+
+      const {error} = await runCommand(Cmd, [
+        'myorg',
+        '--app=my-app',
+        '--confirm=myorg',
+      ]);
+
+      expect(error).to.exist;
+      expect(stripAnsi(error!.message)).to.contain("Data Cloud connection myorg doesn't exist on app my-app.");
+    });
+
+    it('errors when the wrong org name is passed to the confirm flag', async function () {
+      applinkApi
+        .get('/addons/01234567-89ab-cdef-0123-456789abcdef/connections/datacloud/myorg/data_action_targets')
+        .reply(200, []);
+      applinkApi
+        .delete('/addons/01234567-89ab-cdef-0123-456789abcdef/connections/myorg')
+        .optionally()
+        .reply(202, connection5_disconnecting);
+
+      const {error} = await runCommand(Cmd, [
+        'myorg',
+        '--app=my-app',
+        '--confirm=myorg2',
+      ]);
+
+      expect(error).to.exist;
+    });
+  });
+
+  context('when app has no AppLink add-on', function () {
+    beforeEach(function () {
+      process.env = {};
+      nock('https://api.heroku.com')
+        .get('/apps/my-app')
+        .reply(200, app)
+        .get('/apps/my-app/addons')
+        .reply(200, [])
+        .get('/apps/my-app/addon-attachments')
+        .reply(200, [])
+        .get('/apps/my-app/config-vars')
+        .reply(200, {});
+    });
+
+    afterEach(function () {
+      process.env = env;
+      nock.cleanAll();
+    });
+
+    it('shows an error that AppLink is not installed', async function () {
+      const {error} = await runCommand(Cmd, [
+        'myorg',
+        '--app=my-app',
+        '--confirm=myorg',
+      ]);
+
+      expect(error).to.exist;
+      expect(stripAnsi(error!.message)).to.contain("AppLink add-on isn't present on my-app");
+    });
+  });
+
+  context(
+    'when app has multiple AppLink add-ons without --addon flag',
+    function () {
+      beforeEach(function () {
+        process.env = {};
+        nock('https://api.heroku.com')
+          .get('/apps/my-app')
+          .reply(200, app)
+          .get('/apps/my-app/addons')
+          .reply(200, [addon, {...addon2, app}])
+          .get('/apps/my-app/addon-attachments')
+          .reply(200, [addonAttachment, addonAttachment2])
+          .get('/apps/my-app/config-vars')
+          .reply(200, {
+            HEROKU_APPLINK_API_URL:
+              'https://applink-api.heroku.com/addons/01234567',
+            HEROKU_APPLINK_TOKEN: 'token',
+          });
+      });
+
+      afterEach(function () {
+        process.env = env;
+        nock.cleanAll();
+      });
+
+      it('shows an error to specify --addon flag', async function () {
+        const {error} = await runCommand(Cmd, [
+          'myorg',
+          '--app=my-app',
+          '--confirm=myorg',
+        ]);
+
+        expect(error).to.exist;
+        expect(stripAnsi(error!.message)).to.contain('multiple AppLink add-ons');
+      });
+    },
+  );
+});


### PR DESCRIPTION
<!--
When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`). This is how we manage package versioning and generating CHANGELOG notes.

Examples:
- "feat: add growl notification to spaces:wait"
- "fix: handle special characters in app names"
- "chore: add dist directory to .gitignore"

The expected Conventional Commit types are listed below.

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->

## Summary

refactor: As part of larger security work around CLI files, we are upgrading this plugin to oclif v4. In this PR we are also migrating all of the datacloud commands.

Migrating the datacloud commands in the following directories to use oclif/core v4, heroku-cli-command v12, and helper functions from heroku-cli-util as needed:

- applink/datacloud
- applink/datacloud/authorizations
- applink/datacloud/data-action-target

This is PR 4 and a branch that will be merged back into the overall feature branch feature/plugin_migration_applink


## Type of Change

### Breaking Changes (major semver update)

- [ ] Add a `!` after your change type to denote a change that breaks current
      behavior

### Feature Additions (minor semver update)

- [ ] **feat**: Introduces a new feature to the codebase

### Patch Updates (patch semver update)

- [ ] **fix**: Bug fix
- [ ] **perf**: Performance improvement
- [x] **deps**: Dependency upgrade
- [ ] **revert**: Revert a previous commit
- [x] **docs**: Documentation change
- [x] **style**: Styling update
- [ ] **chore**: Change that does not affect production code
- [x] **refactor**: Refactoring existing code without changing behavior
- [x] **tests**: Add/update/remove tests
- [x] **build**: Change to the build system
- [x] **ci**: Continuous integration workflow update

## Testing

The --help changes (should be limited to --prompt and GLOBAL FLAGS additions that came with cli upgrades):

diff <(./bin/run datacloud:connect --help) <(heroku datacloud:connect --help)
diff <(./bin/run datacloud:disconnect --help) <(heroku datacloud:disconnect --help)
diff <(./bin/run datacloud:authorizations:add --help) <(heroku datacloud:authorizations:add --help)
diff <(./bin/run datacloud:authorizations:jwt:add --help) <(heroku datacloud:authorizations:jwt:add --help)
diff <(./bin/run datacloud:authorizations:remove --help) <(heroku datacloud:authorizations:remove --help)
diff <(./bin/run datacloud:data-action-target:create --help) <(heroku datacloud:data-action-target:create --help)

1. Connect to Datacloud

bin/run datacloud:connect my_dc_org --app nodejs-getting-starteeed

2. Verify your Datacloud connection was created

bin/run applink:connections --app nodejs-getting-starteeed

3. Connect to Datacloud (with a particular browser via a flag confirm safari opens)

bin/run datacloud:connect my_dc_org2 --app nodejs-getting-starteeed --browser safari

4. Disconnect from Datacloud (wrong name in confirmation error in name confirmation)

bin/run datacloud:disconnect my_dc_org --app nodejs-getting-starteeed --confirm wrong_name

5. Disconnect from Datacloud (must confirm to disconnect)

bin/run datacloud:disconnect my_dc_org --app nodejs-getting-starteeed

I could not figure out how to test these

datacloud:authorizations:add
datacloud:authorizations:jwt:add
datacloud:data-action-target:create (tested the command works, returns errors because I don't have a data cloud action target)

## Screenshots (if applicable)

## Related Issues

GitHub issue: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002Yz8YxYAJ/view
