### PR TITLE
chore: align dependabot prefixes with release-please changelog sections

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,7 @@ updates:
       day: 'sunday'
       timezone: 'America/Los_Angeles'
     commit-message:
-      prefix: 'chore'
+      prefix: 'deps(dev)'
   - package-ecosystem: 'npm'
     directory: '/'
     open-pull-requests-limit: 5
@@ -19,15 +19,14 @@ updates:
       day: 'sunday'
       timezone: 'America/Los_Angeles'
     commit-message:
-      prefix: 'fix'
-      prefix-development: 'chore'
-      include: 'scope'
+      prefix: 'deps'
+      prefix-development: 'deps(dev)'
     groups:
-      dev-deps:
+      dev-patch-minor-dependencies:
         dependency-type: 'development'
-      patch-dependencies:
         update-types:
           - 'patch'
+          - 'minor'
     ignore:
       - dependency-name: '@oclif/core'
         update-types: ['version-update:semver-major']

--- a/.github/release-configs/release-please-config.beta.json
+++ b/.github/release-configs/release-please-config.beta.json
@@ -8,7 +8,27 @@
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
       "prerelease": true,
-      "prerelease-type": "beta"
+      "prerelease-type": "beta",
+      "changelog-sections": [
+        { "type": "feat", "section": "Features" },
+        { "type": "fix", "section": "Bug Fixes" },
+        { "type": "perf", "section": "Performance Improvements" },
+        { "type": "revert", "section": "Reverts" },
+        {
+          "type": "deps",
+          "scope": "dev",
+          "section": "Dependencies",
+          "hidden": true
+        },
+        { "type": "deps", "section": "Dependencies" },
+        { "type": "refactor", "section": "Code Refactoring" },
+        { "type": "docs", "section": "Documentation", "hidden": true },
+        { "type": "style", "section": "Styles", "hidden": true },
+        { "type": "chore", "section": "Miscellaneous Chores", "hidden": true },
+        { "type": "test", "section": "Tests", "hidden": true },
+        { "type": "build", "section": "Build System", "hidden": true },
+        { "type": "ci", "section": "Continuous Integration", "hidden": true }
+      ]
     }
   },
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",

--- a/.github/release-configs/release-please-config.json
+++ b/.github/release-configs/release-please-config.json
@@ -6,7 +6,27 @@
       "changelog-path": "CHANGELOG.md",
       "extra-files": ["README.md"],
       "bump-minor-pre-major": true,
-      "bump-patch-for-minor-pre-major": true
+      "bump-patch-for-minor-pre-major": true,
+      "changelog-sections": [
+        { "type": "feat", "section": "Features" },
+        { "type": "fix", "section": "Bug Fixes" },
+        { "type": "perf", "section": "Performance Improvements" },
+        { "type": "revert", "section": "Reverts" },
+        {
+          "type": "deps",
+          "scope": "dev",
+          "section": "Dependencies",
+          "hidden": true
+        },
+        { "type": "deps", "section": "Dependencies" },
+        { "type": "refactor", "section": "Code Refactoring" },
+        { "type": "docs", "section": "Documentation", "hidden": true },
+        { "type": "style", "section": "Styles", "hidden": true },
+        { "type": "chore", "section": "Miscellaneous Chores", "hidden": true },
+        { "type": "test", "section": "Tests", "hidden": true },
+        { "type": "build", "section": "Build System", "hidden": true },
+        { "type": "ci", "section": "Continuous Integration", "hidden": true }
+      ]
     }
   },
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",


### PR DESCRIPTION
## Summary

Align Dependabot commit-message prefixes with new release-please `changelog-sections` so dependency updates land in the right changelog buckets (or stay hidden). Also expand the dev dependency group.

- `.github/dependabot.yml`
  - github-actions: prefix `chore` -> `deps(dev)`
  - npm: prefix `fix` -> `deps`, prefix-development `chore` -> `deps(dev)`; drop `include: scope`
  - Replace `dev-deps` + `patch-dependencies` groups with a single `dev-patch-minor-dependencies` group covering dev-only `patch` + `minor` updates (production dep updates intentionally get individual PRs)
- `.github/release-configs/release-please-config.json` and `release-please-config.beta.json`
  - Add `changelog-sections`: show `feat`, `fix`, `perf`, `revert`, `deps` (prod), `refactor`; hide `deps(dev)`, `docs`, `style`, `chore`, `test`, `build`, `ci`

## Type of Change

### Patch Updates (patch semver update)

- [x] **chore**: Change that does not affect production code
- [x] **ci**: Continuous integration workflow update

## Testing

**Notes**:

Config-only change. Both JSON configs parse cleanly; YAML is well-formed.

**Steps**:

1. Passing CI suffices.
2. Verify subsequent Dependabot PRs use the new `deps` / `deps(dev)` prefixes.
3. Verify next release-please PR renders changelog sections per the new config.

## Related Issues

GitHub issue: #[GitHub issue number]
GUS work item: [WI number](WI link)